### PR TITLE
update 'Learn and Build' links in index.mdx

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -7,10 +7,10 @@ title: Getting Started
 Welcome to Overture's how-to section. Here you'll find guides and tutorials to help you access and use the Overture datasets. 
 
 ## Learn and Build
-- [Access the data](https://labs.overturemaps.org/how-to/accessing-data).
-- [Query and explore the data](https://labs.overturemaps.org/how-to/exploring-data).
-- Check out projects from the Overture [community](https://labs.overturemaps.org/how-to/exploring-data/community-projects).
-- [Visualize and build with the data](https://labs.overturemaps.org/how-to/visualizing-data).
+- [Access the data](https://docs.overturemaps.org/accessing-data/).
+- [Query and explore the data](https://docs.overturemaps.org/exploring-data/).
+- Check out projects from the Overture [community](https://docs.overturemaps.org/community/).
+- [Visualize and build with the data](https://docs.overturemaps.org/visualizing-data/).
 - Ask questions! Engage with Overture's [schema working group](https://github.com/OvertureMaps/schema/discussions) and [data working group](https://github.com/OvertureMaps/data/discussions) on GitHub. Feedback from the community will help improve future iterations.
 
 ## Dig Deeper 


### PR DESCRIPTION
I found some outdated links under "Learn and Build".