### PR TITLE
Update the latest Overture release to 2024-04-16-beta

### DIFF
--- a/docs/examples/QGIS.mdx
+++ b/docs/examples/QGIS.mdx
@@ -5,8 +5,9 @@ title: Overture Maps + QGIS
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+In this example, we'll show you how to get Overture Maps data into [QGIS](https://www.qgis.org/), a powerful and popular open source geographic information system. QGIS can ingest almost every spatial data format, including [Parquet](https://parquet.apache.org/docs/) and [GeoParquet](https://geoparquet.org/). Once you get your data into QGIS, the sky's the limit for data analysis, data conflation, visualization and beautiful mapmaking. 
 
-[QGIS](https://www.qgis.org/), an open source geographic information system can read a number of geospatial data formats. To read Overture data with QGIS, we just need to obtain the data we want in a format that is compatible with QGIS. Additionally, we recommend installing a version of QGIS with GDAL > 3.5 that can read `(geo)parquet`.
+The trickiest part of this example is making sure you're installing a newer version of QGIS (with GDAL > 3.5) that can directly read `Parquet` and `GeoParquet` files. We'll walk you through the processs.
 
 <details>
 
@@ -101,8 +102,15 @@ import TabItem from '@theme/TabItem';
 
 </Tabs>
 
-## 2. Add the data to QGIS
-Add the data retrieved in the previous step to QGIS as you might any other vector layer. The easiest method is to drag-and-drop the file direclty into the application.
+## 2. Clean the data
 
-<!-- Add images and GIFs? --another -->
+We need to clean the data and unpack values from the nested arrays in the attribute fields. This will make it easier for us to work with the data in QGIS.
+
+More instructions TK.
+
+## 3. Add the data to QGIS
+All of the data files we created in Step 1 are vector files that can be added as layers in QGIS. The easiest method is to drag-and-drop the file(s) directly into the map canvas.
+
+<!-- [Overture parquet files in QGIS](/img/qgis-parquet-drag-drop.gif) -->
+<img src='/img/qgis-parquet-drag-drop.gif' alt='Drag-n-drop parquet files in QGIS' width='65%'/> 
 

--- a/docs/examples/index.mdx
+++ b/docs/examples/index.mdx
@@ -4,4 +4,6 @@ title: Examples
 
 We want to help you get Overture data into whichever tool you love to use. 
 
-generate picture cards for the examples
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />

--- a/docs/getting-data/index.mdx
+++ b/docs/getting-data/index.mdx
@@ -4,9 +4,9 @@ title: Getting Data
 
 import QueryBuilder from '@site/src/components/queryBuilder';
 
-## Official Overture Data Releases
+## Official Overture Maps data release
 
-Overture's data releases are distributed as geoparquet files available on both Amazon S3 and Microsoft Azure Blob Storage. You do not need AWS or Azure accounts to access the data.
+Overture Maps data is distributed as GeopParquet files available on both Amazon S3 and Microsoft Azure Blob Storage. You do not need AWS or Azure accounts to access the data.
 
 The data is available at the following locations:
 
@@ -20,17 +20,17 @@ The latest release path is:
 
 We _strongly recommend_ accessing the data in the cloud by querying it either [locally](locally) or via [cloud services](cloud-services). This allows you to download only the subset of data you want:
 
-## Accessing in the Cloud
+## Accessing in the cloud
 
-1. [DuckDB (local)](locally)
-1. [Amazon Athena](cloud-services/#amazon-athena-aws)
-1. [Microsoft Synapse](cloud-services/#microsft-synapse-azure)
+- [DuckDB (local)](locally)
+- [Amazon Athena](cloud-services/#amazon-athena-aws)
+- [Microsoft Synapse](cloud-services/#microsft-synapse-azure)
 
 However, it is also possible to download the geoparquet files directly:
 
-## Direct Download
+## Direct download
 
-You can download the Parquet files directly from either Azure Blob Storage or Amazon S3 at the locations given above. **Note: the total size of all of the files is a little over 200 GB.**
+You can download the Parquet files directly from either Azure Blob Storage or Amazon S3 at the locations given above. **Note: the total size of all the files is over 200 GB.**
 
 After installing the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html), you can download the files from S3 using the below command. Set `<DESTINATION>` to a local directory path to download the files, or to an `s3://` path you control to copy them into your S3 bucket.
 
@@ -45,12 +45,3 @@ You can download the files from Azure Blob Storage using [Azure Storage Explorer
                 language="text">
 </QueryBuilder>
 
-## Parquet Schema
-
-The Parquet files match the Overture Data Schema for each theme with the following enhancements:
-
-- The `id` column contains unique identifiers in the Global Entity Reference System (GERS) format.
-- The `bbox` column is a `struct` with the following attributes: `minX`, `maxX`, `minY`, `maxY`. This column allows you to craft more efficient spatial queries when running SQL against the cloud.
-- The `geometry` column is encoded as WKB (the files are geoparquet).
-
-Read the [Overture Data Schema Reference](https://docs.overturemaps.org/reference) to understand the Overture Data Schema and see the [`overturemaps/data`](https://github.com/OvertureMaps/data) Github repository for additional information on the latest release.

--- a/docs/getting-data/index.mdx
+++ b/docs/getting-data/index.mdx
@@ -4,7 +4,7 @@ title: Getting Data
 
 import QueryBuilder from '@site/src/components/queryBuilder';
 
-## Official Overture Maps data release
+## Overture Maps data release
 
 Overture Maps data is distributed as GeopParquet files available on both Amazon S3 and Microsoft Azure Blob Storage. You do not need AWS or Azure accounts to access the data.
 

--- a/docs/getting-data/index.mdx
+++ b/docs/getting-data/index.mdx
@@ -6,7 +6,7 @@ import QueryBuilder from '@site/src/components/queryBuilder';
 
 ## Overture Maps data release
 
-Overture Maps data is distributed as GeopParquet files available on both Amazon S3 and Microsoft Azure Blob Storage. You do not need AWS or Azure accounts to access the data.
+Overture Maps data is distributed as GeoParquet files available on both Amazon S3 and Microsoft Azure Blob Storage. You do not need AWS or Azure accounts to access the data.
 
 The data is available at the following locations:
 

--- a/docs/getting-data/more-queries.mdx
+++ b/docs/getting-data/more-queries.mdx
@@ -17,7 +17,7 @@ This query pulls building geometries and selected attributes from the Overture b
 <QueryBuilder query={DetroitBuildings}></QueryBuilder>
 
 
-### Confident Mountains
+### Mountains
 
 This query selects POIs in the mountain category from the Overture places dataset and outputs them to a GeoJSON file.   
 
@@ -31,7 +31,7 @@ Tip: to write the data to a shapefile, replace the last 2 lines with:
 WITH (FORMAT GDAL, DRIVER 'ESRI Shapefile');
 ```
 
-### Country Polygons
+### Country polygons
 
 This query grabs country-level geometries and their attributes from the admins dataset and outputs them to a GeoJSON file. See [here for examples](https://gist.github.com/danabauer/c50979ead5ce33669ff6c47bfa915319) showing the schema changes for this dataset from July 2023 to February 2024 and beyond.
 

--- a/docs/getting-data/overturemaps-py.mdx
+++ b/docs/getting-data/overturemaps-py.mdx
@@ -3,7 +3,7 @@ title: Python Command-line Tool
 ---
  
 ## `overturemaps-py`
-Overture Maps official Python command-line tool helps you download data within a region of interest and converts it to several common geospatial file formats. 
+Overture Maps Python command-line tool helps you download data within a region of interest and converts it to several common geospatial file formats. 
 
 Note: This project is experimental. Things are likely change including the user interface until a stable release. See the [overturemaps-py repository](https://github.com/OvertureMaps/overturemaps-py) for timely updates.
 

--- a/docs/guides/admins.mdx
+++ b/docs/guides/admins.mdx
@@ -3,7 +3,7 @@ title: Admins
 ---
 :::info
 
-Overture Maps [has announced(release-notes/index) the deprecation of the `admins` schema. We are replacing it with the new `divisions` schema, released in April 2024. Both themes will be available to users through June 2024. In the July 2024 release, `admins` will be removed from Overture Maps. We encourage you to begin the transition to `divisions` now.  
+Overture Maps [has announced](release-notes/index) the deprecation of the `admins` schema. We are replacing it with the new `divisions` schema, released in April 2024. The data for `divisions` will be available in the May 2024 release. The schema *and* the data for the two themes will coexist in the June and July releases. In the August 2024 release, `admins` will be removed from Overture Maps. We encourage you to begin the transition to `divisions` now.  
 
 :::
 

--- a/docs/guides/admins.mdx
+++ b/docs/guides/admins.mdx
@@ -3,7 +3,7 @@ title: Admins
 ---
 :::info
 
-Overture Maps [has announced](release-notes/index) the deprecation of the `admins` schema. We are replacing it with the new `divisions` schema, released in April 2024. The data for `divisions` will be available in the May 2024 release. The schema *and* the data for the two themes will coexist in the June and July releases. In the August 2024 release, `admins` will be removed from Overture Maps. We encourage you to begin the transition to `divisions` now.  
+Overture Maps [has announced](/release-notes/) the deprecation of the `admins` schema. We are replacing it with the new `divisions` schema, released in April 2024. The data for `divisions` will be available in the May 2024 release. The schema *and* the data for the two themes will coexist in the June and July releases. In the August 2024 release, `admins` will be removed from Overture Maps. We encourage you to begin the transition to `divisions` now.  
 
 :::
 

--- a/docs/guides/divisions.mdx
+++ b/docs/guides/divisions.mdx
@@ -3,7 +3,7 @@ title: Divisions
 ---
 :::info
 
-Overture Maps [has announced](release-notes/index) the deprecation of the [`admins` schema](/guides/admins). We are replacing it with the new `divisions` schema, released in April 2024. The data for `divisions` will be available in the May 2024 release. The schema *and* the data for the two themes will coexist in the June and July releases. In the August 2024 release, `admins` will be removed from Overture Maps. We encourage you to begin the transition to `divisions` now.
+Overture Maps [has announced](/release-notes/) the deprecation of the [`admins` schema](/guides/admins). We are replacing it with the new `divisions` schema, released in April 2024. The data for `divisions` will be available in the May 2024 release. The schema *and* the data for the two themes will coexist in the June and July releases. In the August 2024 release, `admins` will be removed from Overture Maps. We encourage you to begin the transition to `divisions` now.
 
 :::
 

--- a/docs/guides/divisions.mdx
+++ b/docs/guides/divisions.mdx
@@ -3,7 +3,7 @@ title: Divisions
 ---
 :::info
 
-Overture Maps [has announced(release-notes/index) the deprecation of the [`admins` schema](/guides/admins). We are replacing it with the new `divisions` schema, released in April 2024. Both themes will be available to users through June 2024. In the July 2024 release, `admins` will be removed from Overture Maps. We encourage you to begin the transition to `divisions` now.
+Overture Maps [has announced](release-notes/index) the deprecation of the [`admins` schema](/guides/admins). We are replacing it with the new `divisions` schema, released in April 2024. The data for `divisions` will be available in the May 2024 release. The schema *and* the data for the two themes will coexist in the June and July releases. In the August 2024 release, `admins` will be removed from Overture Maps. We encourage you to begin the transition to `divisions` now.
 
 :::
 

--- a/docs/guides/index.mdx
+++ b/docs/guides/index.mdx
@@ -2,4 +2,6 @@
 title: User Guides
 ---
 
-TOC for directory, cards with graphics.
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -8,9 +8,9 @@ Overture Maps provides free and open map data normalized to a common schema. We 
 
 - [administrative boundaries](guides/divisions) 
 - [base (water, land, land use)](guides/base)
-- [buildings](guide/buildings)
-- [places](guide/places)
-- [transportation](guide/transportation)
+- [buildings](guides/buildings)
+- [places](guides/places)
+- [transportation](guides/transportation)
 
 In this documentation, you'll find explanatory and [reference](https://docs.overturemaps.org/schema/reference/) material, and hands-on examples for accessing and using the Overture Maps data and schema. Welcome to the project!
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -6,13 +6,13 @@ title: Introduction
 
 Overture Maps provides free and open map data normalized to a common schema. We are currently focused on building the following vector data layers: 
 
-- administrative boundaries 
-- base (water, land, land use)
-- buildings
-- places
-- transportation
+- [administrative boundaries](guides/divisions) 
+- [base (water, land, land use)](guides/base)
+- [buildings](guide/buildings)
+- [places](guide/places)
+- [transportation](guide/transportation)
 
-In this documentation, you'll find explanatory and reference material, and hands-on examples for accessing and using the Overture Maps data and schema. We welcome you to the project.
+In this documentation, you'll find explanatory and [reference](https://docs.overturemaps.org/schema/reference/) material, and hands-on examples for accessing and using the Overture Maps data and schema. Welcome to the project!
 
 ## Vision
 

--- a/docs/release-notes/index.mdx
+++ b/docs/release-notes/index.mdx
@@ -23,7 +23,7 @@ maxy → ymax
 The fields are all now [Parquet Float (32-bit)](https://parquet.apache.org/docs/file-format/types/) where as they had previously been distributed as Double (64-bit).
 
 ## Deprecations
-In this release, we implemented a refactor of the `admins` theme called `divisions`. The two themes will coexist for two additional releases (May and June), at which point `divisions` will fully replace `admins`. More information on why we made this change [here](https://github.com/OvertureMaps/schema/discussions/117).
+In this release, we implemented the schema for a refactor of the `admins` theme called `divisions`. The `divisions` data will be available in our May release. After that, the two themes will coexist for two additional releases (June and July), at which point `divisions` will fully replace `admins`. More information on why we made this change [here](https://github.com/OvertureMaps/schema/discussions/117).
 
 ## Theme-specific updates
 See [here](data-attribution) for information about licensing and data attribution for each theme.

--- a/docs/release-notes/index.mdx
+++ b/docs/release-notes/index.mdx
@@ -1,18 +1,79 @@
 ---
-description: Overture's Monthly Release Notes
+description: Overture Maps Monthly Release Notes
 title: Release Notes
 ---
+### **`2024-04-16-beta.0` release**
 
+Here are the highlights for what's new and updated in the Overture Maps `2024-04-16-beta.0` release. This is the first release designated as a "beta" release. The beta designation indicates the data and schema are largely stable. Developers wishing to adopt Overture Maps base layers are encouraged to begin evaluating and providing feedback on the data, schema, and GERS IDs. Depending on the feedback from this release and subsequent releases, we anticipate moving to a production release in the next few months.   
+
+## Breaking changes
+We renamed the `bbox` column fields to align with the upcoming [GeoParquet](https://geoparquet.org/) 1.1 spec. 
+
+```
+minx → xmin
+miny → ymin
+maxx → xmax
+maxy → ymax
+```
+
+The fields are all now [Parquet Float (32-bit)](https://parquet.apache.org/docs/file-format/types/) where as they had previously been distributed as Double (64-bit).
+
+## Deprecations
+In this release, we implemented a refactor of the `admins` theme called `divisions`. The two themes will coexist for two additional releases (May and June), at which point `divisions` will fully replace `admins`. More information on why we made this change [here](https://github.com/OvertureMaps/schema/discussions/117).
+
+## Theme-specific updates
+See [here](data-attribution) for information about licensing and data attribution for each theme.
+
+**Administrative Boundaries Admins/Divisions**
+- Included OSM data up to 4/8.
+- Implemented the `divisions` theme, which has a better defined schema supporting perspectives, different types of polygons, and other new features.
+- Note: see information above about the deprecation of `admins`.
+
+**Base**
+- Included OSM data up to 3/16 (sourced via Daylight Map Distribution v1.44).
+- Included 46M water features, 55M land features, 40M land use features, and 48M infrastructure features.
+- Maintained the original OSM tags remain on all features.
+- Normalized and added `elevation`, `surface`, and `wikidata` as top-level properties.
+
+**Buildings**
+- Included OSM data up to 3/16 (sourced via Daylight Map Distribution v1.44).
+- Included 2.35B conflated building footprints from OSM, Esri Community Maps, Microsoft ML Building Footprints, and Google Open Buildings.
+- Made incremental improvements to further ensure the data conforms to the buildings layer schema.
+- Added 3d attributes from OSM, such as roof shape.
+- Note: The order of conflation is OpenStreetMap → Esri Community Maps → high precision Google Open Buildings → Microsoft ML Building Footprints → lower precision Google Open Buildings. For example, if Esri has a building that does not exist in OSM, we take that building, then we “fill-in” the rest of the map with any ML buildings that do not intersect with either OSM or Esri. We use the 90% precision confidence threshold to delineate between high and lower precision for Google Open Buildings, this threshold varies per s2 cell.
+
+
+**Places**
+- Included ~53M place records.
+- Included GERS stableids propagated from the previous release; roughly 51M of the ids are propagated and 2M are new.
+- Made incremental changes to improve the accuracy and quality of the dataset.
+
+**Transportation**
+- Include OSM data up to 4/7.
+- Classified 12.2M segments as path.
+- Added `is_covered` flag to denote partially enclosed segments.
+- Improved scope merging; fewer access restrictions entries are now required.
+- Fixed a projection issue affecting segment length calculation and linear referencing
+- Promoted `class` to a top-level property.
+- Moved `level` property into `road` property to allow linear referencing. 84% of all segments which had previously dropped `level` will now have that information.
+- Renamed `at` to `between` for ranged linear referencing. 
+- Removed `mode_not` scoping.
+
+
+
+# Previous releases
+
+### **`2024-03-12-alpha.0` release**
 
 Here are the highlights of what's new and updated in Overture's `2024-03-12-alpha.0` release. This release includes a schema change from `camelCase` to `snake_case` for all property names and enumeration member names, an expansion of stable GERS IDs and incremental updates to the schema and datasets. More detailed [schema release notes and a changelog](https://github.com/OvertureMaps/schema/releases/tag/v0.9.0) are available in the `OvertureMaps/schema`.
 
- ### Breaking changes
+## Breaking changes
 We changed `camelCase` to `snake_case` in the schema for properties to be more compatible with some SQL engines. This may break existing code and queries. See [here for an example](/release-notes/breaking-changes) of how this breaking change affects a query to the Admins dataset.
 
-### Deprecations
+## Deprecations
 In the April 2024 release, Overture will implement a refactor of the `Admins` theme called `Divisions`. Admins and Divisions will coexist for three releases, at which point Divisions will fully replace Admins. More information on this change [here](https://github.com/OvertureMaps/schema/discussions/117).
 
-### Theme-specific updates
+## Theme-specific updates
 The data sources for each theme are cited [here](/release-notes/data-attribution).
 
 **Transportation**

--- a/docs/release-notes/index.mdx
+++ b/docs/release-notes/index.mdx
@@ -4,7 +4,11 @@ title: Release Notes
 ---
 ### **`2024-04-16-beta.0` release**
 
-Here are the highlights for what's new and updated in the Overture Maps `2024-04-16-beta.0` release. This is the first release designated as a "beta" release. The beta designation indicates the data and schema are largely stable. Developers wishing to adopt Overture Maps base layers are encouraged to begin evaluating and providing feedback on the data, schema, and GERS IDs. Depending on the feedback from this release and subsequent releases, we anticipate moving to a production release in the next few months.   
+Here are the highlights for what's new and updated in the Overture Maps `2024-04-16-beta.0` release. The "beta" designation indicates the data and schema are largely stable. 
+
+Overture Maps `2024-04-16-beta.0` is available in GeoParquet and stored on AWS and Azure. Users can select the data of interest and download it by following the process outlined [here](https://docs.overturemaps.org/getting-data/).
+
+We encourage developers wishing to adopt Overture Maps base layers to begin evaluating and providing [feedback on the data, schema, and GERS IDs](https://github.com/OvertureMaps/data/discussions). Depending on the feedback from this release and subsequent releases, we anticipate moving to a production release in the next few months.   
 
 ## Breaking changes
 We renamed the `bbox` column fields to align with the upcoming [GeoParquet](https://geoparquet.org/) 1.1 spec. 
@@ -44,12 +48,12 @@ See [here](data-attribution) for information about licensing and data attributio
 
 
 **Places**
-- Included ~53M place records.
-- Included GERS stableids propagated from the previous release; roughly 51M of the ids are propagated and 2M are new.
+- Included ~53 million place records.
+- Included stable GERS IDs propagated from the previous release; roughly 51 million of the IDs are propagated and 2 million are new.
 - Made incremental changes to improve the accuracy and quality of the dataset.
 
 **Transportation**
-- Include OSM data up to 4/7.
+- Included OSM data up to 4/7.
 - Classified 12.2M segments as path.
 - Added `is_covered` flag to denote partially enclosed segments.
 - Improved scope merging; fewer access restrictions entries are now required.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -21,7 +21,7 @@ const config = {
   favicon: 'img/favicon.png',
 
   customFields: {
-    overtureRelease: '2024-03-12-alpha.0',
+    overtureRelease: '2024-04-16-beta.0',
   },
 
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -49,8 +49,8 @@ const sidebars = {
             id: 'guides/feature-model/index',
           },
           items: [
-            'guides/feature-model/geojson',
-            'guides/feature-model/geoparquet',
+            <!--'guides/feature-model/geojson',-->
+            <!--'guides/feature-model/geoparquet',-->
             'guides/feature-model/names',
             'guides/feature-model/scoping-rules',
             ],
@@ -87,7 +87,7 @@ const sidebars = {
       items: [
         'release-notes/data-attribution',
         'release-notes/breaking-changes',
-        'release-notes/deprecation-notices'
+        <!--'release-notes/deprecation-notices'-->
       ]
     },
   ]

--- a/src/queries/athena/hyderabad_buildings.sql
+++ b/src/queries/athena/hyderabad_buildings.sql
@@ -6,7 +6,7 @@ SELECT
     sources[1].dataset AS primary_source,
     CAST(names AS JSON) AS names,
     ST_GeomFromBinary(geometry) AS geometry
-FROM overture
+FROM overture.release.__ATHENA_OVERTURE_RELEASE
 WHERE theme='buildings'
     AND type='building'
     AND  bbox.xmin > 78.4194

--- a/src/queries/athena/seattle_places.sql
+++ b/src/queries/athena/seattle_places.sql
@@ -8,7 +8,7 @@ FROM
     overture.release.__ATHENA_OVERTURE_RELEASE
 WHERE theme='places'
     AND type='place'
-    AND bbox.xmin > -122.4447744
-        AND bbox.xmax < -122.2477071
-        AND bbox.ymin > 47.5621587
-        AND bbox.ymax < 47.7120663
+    AND bbox.xmin > -122.44
+        AND bbox.xmax < -122.25
+        AND bbox.ymin > 47.56
+        AND bbox.ymax < 47.71

--- a/src/queries/duckdb/100_buildings.sql
+++ b/src/queries/duckdb/100_buildings.sql
@@ -2,7 +2,6 @@ LOAD spatial;
 LOAD azure;
 SET azure_storage_connection_string = 'DefaultEndpointsProtocol=https;AccountName=overturemapswestus2;AccountKey=;EndpointSuffix=core.windows.net';
 
-
 SELECT
   id,
   names.primary as primary_name,
@@ -10,10 +9,10 @@ SELECT
   level,
   sources[1].dataset AS primary_source,
   ST_GeomFromWKB(geometry) as geometry
-FROM read_parquet('azure://release/2024-02-15-alpha.0/theme=buildings/type=*/*', filename=true, hive_partitioning=1)
+FROM read_parquet('azure://release/__OVERTURE_RELEASE/theme=buildings/type=*/*', filename=true, hive_partitioning=1)
 WHERE primary_name IS NOT NULL
-AND bbox.xmin > -84.363175999999953
-AND bbox.xmax < -82.418395999999973
-AND bbox.ymin > 41.706621000000041
-AND bbox.ymax < 43.327039000000070
+AND bbox.xmin > -84.36
+AND bbox.xmax < -82.41
+AND bbox.ymin > 41.70
+AND bbox.ymax < 43.32
 LIMIT 25;

--- a/src/queries/duckdb/admin_boundaries.sql
+++ b/src/queries/duckdb/admin_boundaries.sql
@@ -6,7 +6,7 @@ CREATE VIEW admins_view AS (
     SELECT
         *
     FROM
-        read_parquet('s3://overturemaps-us-west-2/release/2024-02-15-alpha.0/theme=admins/type=*/*', filename=true, hive_partitioning=1)
+        read_parquet('s3://overturemaps-us-west-2/release/2024-03-12-alpha.0/theme=admins/type=*/*', filename=true, hive_partitioning=1)
 );
 COPY (
     SELECT

--- a/src/queries/duckdb/buildings_detroit.sql
+++ b/src/queries/duckdb/buildings_detroit.sql
@@ -7,7 +7,7 @@ SELECT
   names.primary as primary_name,
   height,
   ST_GeomFromWKB(geometry) as geometry
-FROM read_parquet('azure://release/2024-03-12-alpha.0/theme=buildings/type=*/*', filename=true, hive_partitioning=1)
+FROM read_parquet('azure://release/__OVERTURE_RELEASE/theme=buildings/type=*/*', filename=true, hive_partitioning=1)
 WHERE primary_name IS NOT NULL
 AND bbox.xmin > -84.36
 AND bbox.xmax < -82.42

--- a/src/queries/duckdb/buildings_detroit.sql
+++ b/src/queries/duckdb/buildings_detroit.sql
@@ -2,16 +2,14 @@ LOAD spatial;
 LOAD azure;
 SET azure_storage_connection_string = 'DefaultEndpointsProtocol=https;AccountName=overturemapswestus2;AccountKey=;EndpointSuffix=core.windows.net';
 
-
 SELECT
   id,
   names.primary as primary_name,
   height,
   ST_GeomFromWKB(geometry) as geometry
-FROM read_parquet('azure://release/2024-02-15-alpha.0/theme=buildings/type=*/*', filename=true, hive_partitioning=1)
-WHERE primary_name IS NOT NULL 
-AND bbox.xmin > -84.363175999999953
-AND bbox.xmax < -82.418395999999973
-AND bbox.ymin > 41.706621000000041
-AND bbox.ymax < 43.327039000000070
-LIMIT 5;
+FROM read_parquet('azure://release/2024-03-12-alpha.0/theme=buildings/type=*/*', filename=true, hive_partitioning=1)
+WHERE primary_name IS NOT NULL
+AND bbox.xmin > -84.36
+AND bbox.xmax < -82.42
+AND bbox.ymin > 41.71
+AND bbox.ymax < 43.33;

--- a/src/queries/duckdb/confident_mountains.sql
+++ b/src/queries/duckdb/confident_mountains.sql
@@ -6,13 +6,13 @@ COPY(
     SELECT
        id,
        names.primary as primary_name,
-       bbox.minx as x,
-       bbox.minx as y,
+       bbox.xmin as x,
+       bbox.ymin as y,
        ST_GeomFromWKB(geometry) as geometry,
        categories.main as main_category,
        sources[1].dataset AS primary_source,
        confidence
-    FROM read_parquet('s3://overturemaps-us-west-2/release/2024-03-12-alpha.0/theme=places/type=*/*', filename=true, hive_partitioning=1)
+    FROM read_parquet('s3://overturemaps-us-west-2/release/__OVERTURE_RELEASE/theme=places/type=*/*', filename=true, hive_partitioning=1)
     WHERE main_category = 'mountain' AND confidence > .90
     ORDER BY confidence DESC
 ) TO 'overture_places_mountains_gt90.geojson'

--- a/src/queries/duckdb/confident_mountains.sql
+++ b/src/queries/duckdb/confident_mountains.sql
@@ -3,16 +3,16 @@ LOAD httpfs;
 SET s3_region='us-west-2';
 
 COPY(
-    SELECT 
+    SELECT
        id,
        names.primary as primary_name,
-       bbox.xmin as x,
-       bbox.ymin as y,
+       bbox.minx as x,
+       bbox.minx as y,
        ST_GeomFromWKB(geometry) as geometry,
        categories.main as main_category,
        sources[1].dataset AS primary_source,
        confidence
-    FROM read_parquet('s3://overturemaps-us-west-2/release/2024-02-15-alpha.0/theme=places/type=*/*', filename=true, hive_partitioning=1)
+    FROM read_parquet('s3://overturemaps-us-west-2/release/2024-03-12-alpha.0/theme=places/type=*/*', filename=true, hive_partitioning=1)
     WHERE main_category = 'mountain' AND confidence > .90
     ORDER BY confidence DESC
 ) TO 'overture_places_mountains_gt90.geojson'

--- a/src/queries/duckdb/countries_from_azure.sql
+++ b/src/queries/duckdb/countries_from_azure.sql
@@ -6,14 +6,14 @@ COPY (
     SELECT
            type,
            subType,
-           localityType,
-           adminLevel,
-           isoCountryCodeAlpha2,
+           locality_type,
+           admin_level,
+           iso_country_code_alpha_2,
            JSON(names) AS names,
            JSON(sources) AS sources,
            ST_GeomFromWkb(geometry) AS geometry
-      FROM read_parquet('azure://release/__OVERTURE_RELEASE/theme=admins/type=*/*', filename=true, hive_partitioning=1)
-     WHERE adminLevel = 2
+      FROM read_parquet('azure://release/2024-03-12-alpha.0/theme=admins/type=*/*', filename=true, hive_partitioning=1)
+     WHERE admin_level = 2
        AND ST_GeometryType(ST_GeomFromWkb(geometry)) IN ('POLYGON','MULTIPOLYGON')
 ) TO 'countries.geojson'
 WITH (FORMAT GDAL, DRIVER 'GeoJSON', SRS 'EPSG:4326');

--- a/src/queries/duckdb/countries_from_s3.sql
+++ b/src/queries/duckdb/countries_from_s3.sql
@@ -5,15 +5,15 @@ SET s3_region='us-west-2';
 COPY (
     SELECT
            type,
-           subType,
-           localityType,
-           adminLevel,
-           isoCountryCodeAlpha2,
+           subtype,
+           locality_type,
+           admin_level,
+           iso_country_code_alpha_2,
            JSON(names) AS names,
            JSON(sources) AS sources,
            ST_GeomFromWkb(geometry) AS geometry
-      FROM read_parquet('s3://overturemaps-us-west-2/release/__OVERTURE_RELEASE/theme=admins/type=*/*', filename=true, hive_partitioning=1)
-     WHERE adminLevel = 2
+      FROM read_parquet('s3://overturemaps-us-west-2/release/2024-03-12-alpha.0/theme=admins/type=*/*', filename=true, hive_partitioning=1)
+     WHERE admin_level = 2
        AND ST_GeometryType(ST_GeomFromWkb(geometry)) IN ('POLYGON','MULTIPOLYGON')
 ) TO 'countries.geojson'
 WITH (FORMAT GDAL, DRIVER 'GeoJSON', SRS 'EPSG:4326');

--- a/src/queries/duckdb/country_level_geometries.sql
+++ b/src/queries/duckdb/country_level_geometries.sql
@@ -2,29 +2,29 @@ LOAD httpfs;
 LOAD spatial;
 SET s3_region='us-west-2';
 
-CREATE VIEW admins_view AS (
+CREATE OR REPLACE VIEW admins_view AS (
     SELECT
         *
     FROM
-        read_parquet('s3://overturemaps-us-west-2/release/2024-02-15-alpha.0/theme=admins/type=*/*', filename=true, hive_partitioning=1)
+        read_parquet('s3://overturemaps-us-west-2/release/2024-03-12-alpha.0/theme=admins/type=*/*', filename=true, hive_partitioning=1)
 );
 COPY (
     SELECT
             admins.id,
-            admins.subType,
-            admins.isoCountryCodeAlpha2,
+            admins.subtype,
+            admins.iso_country_code_alpha_2,
             names.primary AS primary_name,
             sources[1].dataset AS primary_source,
-            areas.areaId,
-            ST_GeomFromWKB(areas.areaGeometry) as geometry
+            areas.area_id,
+            ST_GeomFromWKB(areas.area_geometry) as geometry
     FROM admins_view AS admins
     INNER JOIN (
         SELECT
-            id as areaId,
-            localityId,
-            geometry AS areaGeometry
+            id as area_id,
+            locality_id,
+            geometry AS area_geometry
         FROM admins_view
-    ) AS areas ON areas.localityId == admins.id
-    WHERE admins.adminLevel = 1
+    ) AS areas ON areas.locality_id == admins.id
+    WHERE admins.admin_level = 1
 ) TO 'countries.geojson'
 WITH (FORMAT GDAL, DRIVER 'GeoJSON');

--- a/src/queries/duckdb/hyderabad_buildings.sql
+++ b/src/queries/duckdb/hyderabad_buildings.sql
@@ -10,7 +10,7 @@ COPY (
         sources[1].dataset AS primary_source,
         JSON(sources) AS sources,
         ST_GeomFromWkb(geometry) AS geometry
-    FROM read_parquet('s3://overturemaps-us-west-2/release/2024-02-15-alpha.0/theme=buildings/type=*/*', filename=true, hive_partitioning=1)
+    FROM read_parquet('s3://overturemaps-us-west-2/release/__OVERTURE_RELEASE/theme=buildings/type=*/*', filename=true, hive_partitioning=1)
     WHERE
         bbox.xmin > 78.4194
         AND bbox.xmax < 78.5129

--- a/src/queries/duckdb/seattle_places.sql
+++ b/src/queries/duckdb/seattle_places.sql
@@ -20,9 +20,9 @@ COPY (
     FROM
        read_parquet('s3://overturemaps-us-west-2/release/__OVERTURE_RELEASE/theme=places/type=*/*', hive_partitioning=1)
     WHERE
-        bbox.xmin > -122.4447744
-        AND bbox.xmax < -122.2477071
-        AND bbox.xmin > 47.5621587
-        AND bbox.xmax < 47.7120663
+        bbox.xmin > -122.44
+        AND bbox.xmax < -122.25
+        AND bbox.xmin > 47.56
+        AND bbox.xmax < 47.71
     ) TO 'places_seattle.geojsonseq'
 WITH (FORMAT GDAL, DRIVER 'GeoJSONSeq', SRS 'EPSG:4326');


### PR DESCRIPTION
This PR updates the docusaurus config to reference the new beta release. 

Consequently, there are a number of schema changes that need to be changed, such as the bbox query. Most of those are already done.

Must confirm the actual production path to the release before merging: https://github.com/OvertureMaps/docs/pull/26/files#r1566427009

Other notable pieces here: 
- Updated some queries to reference the latest Overture release `__OVERTURE_RELEASE`
- Hardcoded anything referencing admins to the March release because we are beginning the deprecation process in favor of `divisions`.