### PR TITLE
clarify that divisions data is available in this release

### DIFF
--- a/docs/guides/admins.mdx
+++ b/docs/guides/admins.mdx
@@ -3,7 +3,7 @@ title: Admins
 ---
 :::info
 
-Overture Maps [has announced](/release-notes/) the deprecation of the `admins` schema. We are replacing it with the new `divisions` schema, released in April 2024. The data for `divisions` will be available in the May 2024 release. The schema *and* the data for the two themes will coexist in the June and July releases. In the August 2024 release, `admins` will be removed from Overture Maps. We encourage you to begin the transition to `divisions` now.  
+Overture Maps [has announced](/release-notes/) the deprecation of the `admins` theme, to be replaced with a new `divisions` theme. As of the April 2024 release, `divisions` is available to users. Both `admins` and `divisions` will coexist for the next two releases (May and June). In the July 2024 release, `admins` will be removed from Overture Maps. We encourage you to begin the transition to `divisions` now.  
 
 :::
 

--- a/docs/guides/divisions.mdx
+++ b/docs/guides/divisions.mdx
@@ -3,7 +3,7 @@ title: Divisions
 ---
 :::info
 
-Overture Maps [has announced](/release-notes/) the deprecation of the [`admins` schema](/guides/admins). We are replacing it with the new `divisions` schema, released in April 2024. The data for `divisions` will be available in the May 2024 release. The schema *and* the data for the two themes will coexist in the June and July releases. In the August 2024 release, `admins` will be removed from Overture Maps. We encourage you to begin the transition to `divisions` now.
+Overture Maps [has announced](/release-notes/) the deprecation of the `admins` theme, to be replaced with a new `divisions` theme. As of the April 2024 release, `divisions` is available to users. Both `admins` and `divisions` will coexist for the next two releases (May and June). In the July 2024 release, `admins` will be removed from Overture Maps. We encourage you to begin the transition to `divisions` now.
 
 :::
 

--- a/docs/release-notes/index.mdx
+++ b/docs/release-notes/index.mdx
@@ -23,7 +23,7 @@ maxy → ymax
 The fields are all now [Parquet Float (32-bit)](https://parquet.apache.org/docs/file-format/types/) where as they had previously been distributed as Double (64-bit).
 
 ## Deprecations
-In this release, we implemented the schema for a refactor of the `admins` theme called `divisions`. The `divisions` data will be available in our May release. After that, the two themes will coexist for two additional releases (June and July), at which point `divisions` will fully replace `admins`. More information on why we made this change [here](https://github.com/OvertureMaps/schema/discussions/117).
+In this release, we implemented a refactor of the `admins` theme called `divisions`. The `divisions` schema and data are [now available](/guides/divisions). The two themes will coexist for two subsequent releases (May 2024 and June 2024), at which point `divisions` will fully replace `admins`. More information on why we made this change [here](https://github.com/OvertureMaps/schema/discussions/117).
 
 ## Theme-specific updates
 See [here](data-attribution) for information about licensing and data attribution for each theme.


### PR DESCRIPTION
This is a quick fix to make it clear to users that both the schema *and* data for `divisions` are available to users in the April release. I updated the text on these pages:
- guides/admins
- guides/divisions
- release-notes