### PR TITLE
Typo : Fix : Zoom level on places

### DIFF
--- a/docs/examples/build-a-map.mdx
+++ b/docs/examples/build-a-map.mdx
@@ -71,7 +71,7 @@ The admins theme contains named localities and their administrative boundaries. 
         <summary>Tippecanoe flag explanation</summary>
 
     - `-fo placenames.pmtiles` is our output file. It will be overwritten if it exists.
-    - `-Z5` and `-z10` will produce a tileset starting at zoom 5 and going up to zoom 13.
+    - `-Z5` and `-z10` will produce a tileset starting at zoom 5 and going up to zoom 10.
     - `-l placenames` names the layer "placenames"
 
     </details>


### PR DESCRIPTION
### What does this PR do ? 

- Fixes the typo on flag explanation for the zoom level 
<img width="753" alt="image" src="https://github.com/OvertureMaps/docs/assets/36752999/95503520-ff91-48ed-b283-1fe227cc6e7e">
