### PR TITLE
release notes and property tables

### DIFF
--- a/docs/guides/base.mdx
+++ b/docs/guides/base.mdx
@@ -1,9 +1,15 @@
 ---
-title: Base
+title: Working Overture Maps base layers
 ---
 ## Overview
 
-The Overture Maps `base` theme provides the land and water features that are necessary to render a complete basemap. These features are currently derived from the [Daylight Earth Tables](https://daylightmap.org/earth/) schema and include the [Daylight Coastlines](https://daylightmap.org/coastlines.html).
+The Overture Maps `base` theme provides the land and water features that are necessary to render a complete basemap. These features are currently derived from the [Daylight Earth Tables](https://daylightmap.org/earth/) schema and include the [Daylight Coastlines](https://daylightmap.org/coastlines.html). The theme includes five feature types:
+
+- **`infrastructure`**: Infrastructure features such as communication towers and lines, piers, and bridges.
+- **`land`**: physical representations of land surfaces derived from the inverse of OSM Coastlines; translates natural tags from OpenStreetMap.
+- **`land_use`**: classifications of the human use of a section of land; translates landuse tag from OpenStreetMap.
+- **`water`**: physical representations of inland and ocean marine surfaces; translates natural and waterway tags from OpenStreetMap.
+- **`land_cover`**: derived from [ESA WorldCover](https://esa-worldcover.org/en), high-resolution optical Earth observation data.
 
 ## Schema design choices
 
@@ -12,17 +18,11 @@ The Overture Maps `base` theme provides the land and water features that are nec
 - extraction of consistent OSM tags, such as `wikidata` to top-level properties.
 - direct pass-through of remaining relevant OSM tags.
 
-## Current feature types
-
-- [infrastructure](https://docs.overturemaps.org/schema/reference/base/infrastructure): Infrastructure features such as communication towers and lines, piers, and bridges.
-- [land](https://docs.overturemaps.org/schema/reference/base/land): physical representations of land surfaces. Global land derived from the inverse of OSM Coastlines. Translates `natural` tags from OpenStreetMap.
-- [land_use](https://docs.overturemaps.org/schema/reference/base/land-use): classifications of the human use of a section of land. Translates `landuse` from OpenStreetMap tag from OpenStreetMap.
-- [water](https://docs.overturemaps.org/reference/schema/base/water): physical representations of inland and ocean marine surfaces. Translates `natural` and `waterway` tags from OpenStreetMap.
-
 ## Schema reference
 
 - [Explore the schema for the infrastructure feature type](https://docs.overturemaps.org/schema/reference/base/infrastructure).
 - [Explore the schema for the land feature type](https://docs.overturemaps.org/schema/reference/base/land).
-- [Explore the schema for the land use feature type](https://docs.overturemaps.org/schema/reference/base/land-use).
+- [Explore the schema for the land use feature type](https://docs.overturemaps.org/schema/reference/base/land_use).
 - [Explore the schema for the water feature type](https://docs.overturemaps.org/schema/reference/base/water). 
+- [Explore the schema for the land cover feature type](https://docs.overturemaps.org/schema/reference/base/land_cover). 
 

--- a/docs/guides/buildings.mdx
+++ b/docs/guides/buildings.mdx
@@ -23,8 +23,6 @@ The Overture Maps `buildings` theme describes human-made structures with roofs o
 | id               | varchar | 
 | geometry         | blob    | 
 | bbox             | struct  |
-| version          | integer | 
-| update_time      | varchar | 
 | sources          | struct  |
 | subtype          | varchar |
 | names            | struct  | 
@@ -43,9 +41,7 @@ The Overture Maps `buildings` theme describes human-made structures with roofs o
 | roof_orientation | varchar | 
 | roof_color       | varchar |  
 | eave_height      | double  | 
-| filename         | varchar | 
-| theme            | varchar | 
-| type             | varchar | 
+
 </TabItem>
 <TabItem value="building_part" label="building_part" default>
 | column           | type    | 
@@ -53,8 +49,6 @@ The Overture Maps `buildings` theme describes human-made structures with roofs o
 | id               | varchar | 
 | geometry         | blob    | 
 | bbox             | struct  |
-| version          | integer | 
-| update_time      | varchar | 
 | sources          | struct  |
 | names            | struct  | 
 | class            | varchar | 
@@ -71,9 +65,7 @@ The Overture Maps `buildings` theme describes human-made structures with roofs o
 | roof_orientation | varchar | 
 | roof_color       | varchar |  
 | building_id      | varchar | 
-| filename         | varchar | 
-| theme            | varchar | 
-| type             | varchar | 
+
 </TabItem>
 </Tabs>
 </div>

--- a/docs/guides/buildings.mdx
+++ b/docs/guides/buildings.mdx
@@ -12,7 +12,9 @@ The Overture Maps `buildings` theme describes human-made structures with roofs o
 - **`building`**: The most basic form of a building feature. The geometry is expected to be the most outer footprint -- or roofprint if traced from satellite/aerial imagery -- of a building.
 - **`building_part`**: A single part of a building. Building parts may have the same properties as buildings, including color, material, and shape. A building part is associated with a parent building via a `building_id`, if its geometry is contained within the building footprint.
 
-The datasets are available as GeoParquet files with the following attributes: 
+<details>
+        <summary>Attribute tables for the GeoParquet files in the buildings theme</summary> 
+        <div>
 <Tabs>
 <TabItem value="building" label="building" default>
 
@@ -74,6 +76,8 @@ The datasets are available as GeoParquet files with the following attributes:
 | type             | varchar | 
 </TabItem>
 </Tabs>
+</div>
+</details>
 
 
 

--- a/docs/guides/buildings.mdx
+++ b/docs/guides/buildings.mdx
@@ -1,15 +1,82 @@
 ---
-title: Buildings
+title: Working with buildings data
 ---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import QueryBuilder from '@site/src/components/queryBuilder';
+
 
 ## Overview
 
-The Overture Maps `buildings` theme describes human-made structures with roofs or interior spaces that are permanently or semi-permanently in one place (source: [OSM building definition](https://wiki.openstreetmap.org/wiki/Key:building)).
+The Overture Maps `buildings` theme describes human-made structures with roofs or interior spaces that are permanently or semi-permanently in one place (source: [OSM building definition](https://wiki.openstreetmap.org/wiki/Key:building)). The theme includes two feature types:
+- **`building`**: The most basic form of a building feature. The geometry is expected to be the most outer footprint -- or roofprint if traced from satellite/aerial imagery -- of a building.
+- **`building_part`**: A single part of a building. Building parts may have the same properties as buildings, including color, material, and shape. A building part is associated with a parent building via a `building_id`, if its geometry is contained within the building footprint.
 
-## Key schema design choices
+The datasets are available as GeoParquet files with the following attributes: 
+<Tabs>
+<TabItem value="building" label="building" default>
 
-- **Extensible attributes.** Overture starts from a basic model containing footprint polygons and a small number of optional attributes. Attributes currently not covered in the official schema release are allowed to exist with the prefix `ext` in their name.
-- **Easy transformation from other data sources.** Classes such as `residential`, `commercial` or `education` are intended to be broad categories in which many different OSM tagging combinations can map to the same class.
+| column           | type    | 
+| ---------------- | ------- | 
+| id               | varchar | 
+| geometry         | blob    | 
+| bbox             | struct  |
+| version          | integer | 
+| update_time      | varchar | 
+| sources          | struct  |
+| subtype          | varchar |
+| names            | struct  | 
+| class            | varchar | 
+| level            | integer | 
+| has_parts        | boolean | 
+| height           | double  |
+| num_floors       | integer | 
+| min_height       | double  | 
+| min_floor        | integer | 
+| facade_color     | varchar | 
+| facade_material  | varchar | 
+| roof_material    | varchar | 
+| roof_shape       | varchar | 
+| roof_direction   | double  | 
+| roof_orientation | varchar | 
+| roof_color       | varchar |  
+| eave_height      | double  | 
+| filename         | varchar | 
+| theme            | varchar | 
+| type             | varchar | 
+</TabItem>
+<TabItem value="building_part" label="building_part" default>
+| column           | type    | 
+| ---------------- | ------- | 
+| id               | varchar | 
+| geometry         | blob    | 
+| bbox             | struct  |
+| version          | integer | 
+| update_time      | varchar | 
+| sources          | struct  |
+| names            | struct  | 
+| class            | varchar | 
+| level            | integer | 
+| height           | double  |
+| num_floors       | integer | 
+| min_height       | double  | 
+| min_floor        | integer | 
+| facade_color     | varchar | 
+| facade_material  | varchar | 
+| roof_material    | varchar | 
+| roof_shape       | varchar | 
+| roof_direction   | double  | 
+| roof_orientation | varchar | 
+| roof_color       | varchar |  
+| building_id      | varchar | 
+| filename         | varchar | 
+| theme            | varchar | 
+| type             | varchar | 
+</TabItem>
+</Tabs>
+
+
+
 
 ## Schema reference
 

--- a/docs/guides/buildings.mdx
+++ b/docs/guides/buildings.mdx
@@ -18,53 +18,52 @@ The Overture Maps `buildings` theme describes human-made structures with roofs o
 <Tabs>
 <TabItem value="building" label="building" default>
 
-| column           | type    | 
-| ---------------- | ------- | 
-| id               | varchar | 
-| geometry         | blob    | 
-| bbox             | struct  |
-| sources          | struct  |
-| subtype          | varchar |
-| names            | struct  | 
-| class            | varchar | 
-| level            | integer | 
-| has_parts        | boolean | 
-| height           | double  |
-| num_floors       | integer | 
-| min_height       | double  | 
-| min_floor        | integer | 
-| facade_color     | varchar | 
-| facade_material  | varchar | 
-| roof_material    | varchar | 
-| roof_shape       | varchar | 
-| roof_direction   | double  | 
-| roof_orientation | varchar | 
-| roof_color       | varchar |  
-| eave_height      | double  | 
+| column           | type    | description |
+| ---------------- | ------- | ------------ |
+| id               | varchar | A feature ID that may be associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
+| geometry         | blob    |  A building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). MUST be a Polygon as defined by GeoJSON schema. | 
+| bbox             | struct  | Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
+| sources          | struct  | The array of source information for the properties of a given feature. Each source object lists the property in JSON Pointer notation and the dataset from which that specific value originated. | 
+| subtype          | varchar | A broad category of the building type and purpose. | 
+| names            | struct  | The name associated with the feature. The first entry in the array of names must have a "local" language. | 
+| class            | varchar | Further delineation of the building's built purpose. | 
+| level            | integer | The building feature's Z-order, i.e., stacking order. A Z-order of 0 is ground level. |
+| has_parts        | boolean | Flag indicating whether the building has parts. | 
+| height           | double  | Height of the building or part in meters. The height is the distance from the lowest point to the highest point. | 
+| num_floors       | integer | Number of above-ground floors of the building or part. | 
+| min_height       | double  | The height of the bottom part of building in meters. Used if a building or part of building starts above the ground level. | 
+| min_floor        | integer | The "start" floor of a building or building part. Indicates that the building or part is "floating" and its bottom-most floor is above ground level, usually because it is part of a larger building in which some parts do reach ground level. | 
+| facade_color     | varchar | The color (name or color triplet) of the facade of a building or building part in hexadecimal. | 
+| facade_material  | varchar | The outer surface material of building facade. | 
+| roof_material    | varchar | The outermost material of the roof. | 
+| roof_shape       | varchar | The shape of the roof. | 
+| roof_direction   | double  | Bearing of the roof ridge line. | 
+| roof_orientation | varchar | Orientation of the roof shape relative to the footprint shape. Either "along" or "across." |
+| roof_color       | varchar |  The color (name or color triplet) of the roof of a building or building part in hexadecimal. | 
 
 </TabItem>
 <TabItem value="building_part" label="building_part" default>
-| column           | type    | 
-| ---------------- | ------- | 
-| id               | varchar | 
-| geometry         | blob    | 
-| bbox             | struct  |
-| sources          | struct  |
-| names            | struct  | 
-| class            | varchar | 
-| level            | integer | 
-| height           | double  |
-| num_floors       | integer | 
-| min_height       | double  | 
-| min_floor        | integer | 
-| facade_color     | varchar | 
-| facade_material  | varchar | 
-| roof_material    | varchar | 
-| roof_shape       | varchar | 
-| roof_direction   | double  | 
-| roof_orientation | varchar | 
-| roof_color       | varchar |  
-| building_id      | varchar | 
+| column           | type    | description |
+| ---------------- | ------- | ------------ |
+| id               | varchar | A feature ID that may be associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
+| geometry         | blob    |  A building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). MUST be a Polygon as defined by GeoJSON schema. | 
+| bbox             | struct  | Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
+| sources          | struct  | The array of source information for the properties of a given feature. Each source object lists the property in JSON Pointer notation and the dataset from which that specific value originated. | 
+| names            | struct  | The name associated with the feature. The first entry in the array of names must have a "local" language. | 
+| class            | varchar | Further delineation of the building's built purpose. | 
+| level            | integer | The building feature's Z-order, i.e., stacking order. A Z-order of 0 is ground level. |
+| height           | double  | Height of the building or part in meters. The height is the distance from the lowest point to the highest point. | 
+| num_floors       | integer | Number of above-ground floors of the building or part. | 
+| min_height       | double  | The height of the bottom part of building in meters. Used if a building or part of building starts above the ground level. | 
+| min_floor        | integer | The "start" floor of a building or building part. Indicates that the building or part is "floating" and its bottom-most floor is above ground level, usually because it is part of a larger building in which some parts do reach ground level. | 
+| facade_color     | varchar | The color (name or color triplet) of the facade of a building or building part in hexadecimal. | 
+| facade_material  | varchar | The outer surface material of building facade. | 
+| roof_material    | varchar | The outermost material of the roof. | 
+| roof_shape       | varchar | The shape of the roof. | 
+| roof_direction   | double  | Bearing of the roof ridge line. | 
+| roof_orientation | varchar | Orientation of the roof shape relative to the footprint shape. Either "along" or "across." |
+| roof_color       | varchar |  The color (name or color triplet) of the roof of a building or building part in hexadecimal. |  
+| building_id      | varchar | The building ID to which this part belongs.|
 
 </TabItem>
 </Tabs>

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -4,15 +4,15 @@ slug: /
 title: Introduction
 ---
 
-Overture Maps provides free and open map data normalized to a common schema. We are currently focused on building the following vector data layers: 
+Welcome! Overture Maps provides free and open map data normalized to a common schema. We are currently focused on building the following vector data layers: 
 
-- [administrative boundaries](guides/admins) 
-- [base (water, land, land use)](guides/base)
+- [administrative boundaries](guides/divisions) 
+- [base: water, land, land use, infrastructure, land cover](guides/base)
 - [buildings](guides/buildings)
 - [places](guides/places)
 - [transportation](guides/transportation)
 
-In this documentation, you'll find explanatory and [reference](https://docs.overturemaps.org/schema) material, and hands-on examples for accessing and using the Overture Maps data and schema. Welcome to the project!
+In this documentation, you'll find [reference](https://docs.overturemaps.org/schema) material, [instructions](getting-data) for accessing our data, and [hands-on examples](examples) to help you start exploring and building.
 
 ## Vision
 

--- a/docs/release-notes/archived.mdx
+++ b/docs/release-notes/archived.mdx
@@ -3,9 +3,75 @@ description: Overture Maps Monthly Release Notes
 title: Archived
 ---
 
+## **`2024-04-16-beta.0` release**
+
+Here are the highlights for what's new and updated in the Overture Maps `2024-04-16-beta.0` release. The "beta" designation indicates the data and schema are largely stable. 
+
+Overture Maps `2024-04-16-beta.0` is available in GeoParquet and stored on AWS and Azure. Users can select the data of interest and download it by following the process outlined [here](https://docs.overturemaps.org/getting-data/).
+
+We encourage developers wishing to adopt Overture Maps base layers to begin evaluating and providing [feedback on the data, schema, and GERS IDs](https://github.com/OvertureMaps/data/discussions). Depending on the feedback from this release and subsequent releases, we anticipate moving to a production release in the next few months.   
+
+### Breaking changes
+We renamed the `bbox` column fields to align with the upcoming [GeoParquet](https://geoparquet.org/) 1.1 spec. 
+
+```
+minx → xmin
+miny → ymin
+maxx → xmax
+maxy → ymax
+```
+
+The fields are all now [Parquet Float (32-bit)](https://parquet.apache.org/docs/file-format/types/) where as they had previously been distributed as Double (64-bit).
+
+### Deprecations
+In this release, we implemented a refactor of the `admins` theme called `divisions`. The `divisions` schema and data are [now available](/guides/divisions). The two themes will coexist for two subsequent releases (May 2024 and June 2024), at which point `divisions` will fully replace `admins`. More information on why we made this change [here](https://github.com/OvertureMaps/schema/discussions/117).
+
+### Changelog
+See our [changelog](https://github.com/OvertureMaps/schema/releases) here.
+
+### Theme-specific updates
+See [here](attribution) for information about licensing and data attribution for each theme.
+
+**Administrative Boundaries Admins/Divisions**
+- Included OSM data up to 4/8.
+- Implemented the schema for the `divisions` theme, which has a better defined schema supporting perspectives, different types of polygons, and other new features.
+- Note: see information above about the deprecation of `admins`.
+
+**Base**
+- Included OSM data up to 3/16 (sourced via Daylight Map Distribution v1.44).
+- Included 46M water features, 55M land features, 40M land use features, and 48M infrastructure features.
+- Maintained the original OSM tags remain on all features.
+- Normalized and added `elevation`, `surface`, and `wikidata` as top-level properties.
+
+**Buildings**
+- Included OSM data up to 3/16 (sourced via Daylight Map Distribution v1.44).
+- Included 2.35B conflated building footprints from OSM, Esri Community Maps, Microsoft ML Building Footprints, and Google Open Buildings.
+- Made incremental improvements to further ensure the data conforms to the buildings layer schema.
+- Added 3d attributes from OSM, such as roof shape.
+- Note: The order of conflation is OpenStreetMap → Esri Community Maps → high precision Google Open Buildings → Microsoft ML Building Footprints → lower precision Google Open Buildings. For example, if Esri has a building that does not exist in OSM, we take that building, then we “fill-in” the rest of the map with any ML buildings that do not intersect with either OSM or Esri. We use the 90% precision confidence threshold to delineate between high and lower precision for Google Open Buildings, this threshold varies per s2 cell.
+
+**Places**
+- Included ~53 million place records.
+- Included stable GERS IDs propagated from the previous release; roughly 51 million of the IDs are propagated and 2 million are new.
+- Made incremental changes to improve the accuracy and quality of the dataset.
+
+**Transportation**
+- Included OSM data up to 4/7.
+- Classified 12.2M segments as path.
+- Added `is_covered` flag to denote partially enclosed segments.
+- Improved scope merging; fewer access restrictions entries are now required.
+- Fixed a projection issue affecting segment length calculation and linear referencing
+- Promoted `class` to a top-level property.
+- Moved `level` property into `road` property to allow linear referencing. 84% of all segments which had previously dropped `level` will now have that information.
+- Renamed `at` to `between` for ranged linear referencing. 
+- Removed `mode_not` scoping.
+
+### Attribution
+The data sources for each theme are cited [here](/release-notes/attribution).
+
+
 ## **`2024-03-12-alpha.0` release**
 
-### Highlights
 Here are the highlights of what's new and updated in Overture's `2024-03-12-alpha.0` release. This release includes a schema change from `camelCase` to `snake_case` for all property names and enumeration member names, an expansion of stable GERS IDs and incremental updates to the schema and datasets. 
 
 ### Breaking changes
@@ -26,8 +92,11 @@ See our [changelog](https://github.com/OvertureMaps/schema/releases/tag/v0.9.0) 
 - Added support for max weight, height, width and length access restrictions.
 - Added one-way road access restrictions.
 - Added road widths property to segments.
-- Acheived stability of GERS IDs for connectors and segments for this and future releases.
 - Note: data in the transportation theme is licensed under ODbL.
+
+:::note
+GERS IDs for connectors and segments should be considered stable for this and future releases.
+:::
 
 **Administrative Boundaries (Admins)**
 - Refreshed to include OSM data up to 2024-03-07.
@@ -60,16 +129,7 @@ The data sources for each theme are cited [here](/release-notes/attribution).
 
 ## **`2024-02-15-alpha.0` release**
 
-### Highlights
-Overture `2024-02-15-alpha.0` is now available. This release includes several incremental improvements, addition of geopolitical boundary information in the Admins Theme and expansion of GERS IDs across several themes. More information about these additions is available in the relevant sections below. 
-
-This data is formatted in the Overture Data Schema unless otherwise noted. 
-
-This data is available for use under the designated licenses for each theme. 
-
-We would like feedback on the data, its usefulness, and how it could be improved. Please use this Github repo for discussions and feedback related to this data release.
-
-Overture `2024-02-15-alpha.0` is available in GeoParquet and stored on AWS and Azure. 
+Overture `2024-02-15-alpha.0` is now available. This release includes several incremental improvements, addition of geopolitical boundary information in the Admins Theme and expansion of GERS IDs across several themes. More information about these additions is available in the relevant sections below. This data is formatted in the Overture Data Schema unless otherwise noted. This data is available for use under the designated licenses for each theme. Overture `2024-02-15-alpha.0` is available in GeoParquet and stored on AWS and Azure. 
 
 ### Changelog
 See our [changelog](https://github.com/OvertureMaps/schema/releases/tag/v0.8.0) here.
@@ -78,45 +138,39 @@ See our [changelog](https://github.com/OvertureMaps/schema/releases/tag/v0.8.0) 
 Overture `2024-02-15-alpha.0` is released in five themes. 
 
 **Buildings Theme**
-The dataset includes 2.35B conflated building footprints from OSM, Esri Community Maps, Microsoft ML Building Footprints, and Google Open Buildings.
-The order of conflation is OpenStreetMap → Esri Community Maps → high precision Google Open Buildings → Microsoft ML Building Footprints → lower precision Google Open Buildings. For example, if Esri has a building that does not exist in OSM, we take that building, then we “fill-in” the rest of the map with any ML buildings that do not intersect with either OSM or Esri.
-We use the 90% precision confidence threshold to delineate between high and lower precision for Google Open Buildings, this threshold varies per s2 cell.
-
-We've made incremental improvements to further ensure the data conforms to the buildings layer schema.
-
-3d attributes from OSM, such as roof shape, are now available.
-
-The sources of the buildings theme include OpenStreetMap, Esri Community Maps, Microsoft Building footprints, and Google Open Buildings. Some building heights have also been derived using lidar from USGS 3DEP. 
-
-Data in the Buildings theme is licensed under ODbL.
+- The dataset includes 2.35B conflated building footprints from OSM, Esri Community Maps, Microsoft ML Building Footprints, and Google Open Buildings.
+- The order of conflation is OpenStreetMap → Esri Community Maps → high precision Google Open Buildings → Microsoft ML Building Footprints → lower precision Google Open Buildings. For example, if Esri has a building that does not exist in OSM, we take that building, then we “fill-in” the rest of the map with any ML buildings that do not intersect with either OSM or Esri.
+- We use the 90% precision confidence threshold to delineate between high and lower precision for Google Open Buildings, this threshold varies per s2 cell.
+- We've made incremental improvements to further ensure the data conforms to the buildings layer schema.
+- 3d attributes from OSM, such as roof shape, are now available.
+- The sources of the buildings theme include OpenStreetMap, Esri Community Maps, Microsoft Building footprints, and Google Open Buildings. Some building heights have also been derived using lidar from USGS 3DEP. 
+- Data in the Buildings theme is licensed under ODbL.
 
 **Transportation Theme**
 - Refreshed data to include OSM data up to Feb 5
 - Segment names are now a top-level property with a unified schema
 - Access restrictions are now populated for most simple cases
 - OSM source IDs are now included for all segments
+- Data in the Transportation theme is licensed under ODbL.
 
 :::note
 GERS IDs for connectors and segments should now be considered stable for this and future releases
 :::
 
-Data in the Transportation theme is licensed under ODbL.
-
 **Base Theme**
 - All of the features in the base theme are from OpenStreetMap, sourced via the latest Daylight Map Distribution (v1.40).
 - Includes 44M water features, 63M land features, and 34M land use features.
-Most original OSM tags remain on all features. Some tags become normalized and added as top-level properties, such as the surface or wikidata tags.
-
-Data in the Base theme is licensed under ODbL. 
+- Most original OSM tags remain on all features. Some tags become normalized and added as top-level properties, such as the surface or wikidata tags.
+- Data in the Base theme is licensed under ODbL. 
 
 **Places Theme**
-This release has roughly 54M place records. The Places theme in this release includes incremental improvements to improve the accuracy and quality of the dataset.
+- this release has roughly 54M place records
+- incremental improvements to improve the accuracy and quality of the dataset
+- Data in the Places theme is licensed under CDLA Permissive 2.0.
 
 :::note
 For the first time, this release includes GERS stableids propagated from the previous release. Roughly 50M of the ids are propagated and 4M of the ids are new.
 :::
-
-Data in the Places theme is licensed under CDLA Permissive 2.0.
 
 **Administrative Boundaries (Admins) Theme**
 - First version where all countries have second-level subdivisions.
@@ -125,21 +179,16 @@ Data in the Places theme is licensed under CDLA Permissive 2.0.
 - `AdminLevel` property value changed from 2 for Country, 4 for State and 6 for County to be 1 for Country, 2 for State and 3 for County.
 - Added Wikidata and Population properties.
 - All administrative localities now have `isoCountryCodeAlpha2` set for easier filtering to specific country.
+- Data in the Admin theme is licensed under ODbL.
 
 :::note
-Known issue: All first-level subdivisions have type=state and all second-level subdivisions have type=county which is not always true, we plan to address this issue in following release. Will be fixed in March release.
+Known issue: All first-level subdivisions have `type=state` and all second-level subdivisions have `type=county` which is not always true, we plan to address this issue in following release. Will be fixed in March release.
 :::
 
-The sources of the admin theme are OpenStreetMap, geoBoundaries and Esri. 
-
-The Administrative Boundary data is in the Overture Maps data schema for Admin.
-
-Data in the Admin theme is licensed under ODbL.
-
 **Documentation**
-Updated schema, reference and GERS technical documentation.
-Integrated https://labs.overturemaps.org/how-to/ with core documentation.
-Added new guides and tutorials for accessing, exploring  and visualizing data.
+- Updated schema, reference and GERS technical documentation.
+- Integrated https://labs.overturemaps.org/how-to/ with core documentation.
+- Added new guides and tutorials for accessing, exploring  and visualizing data.
 
 ### Attribution
 - © OpenStreetMap contributors available under the Open Database License (www.openstreetmap.org/copyright)
@@ -150,16 +199,7 @@ Added new guides and tutorials for accessing, exploring  and visualizing data.
 
 ## **`2024-01-17-alpha.0` release**
 
-### Highlights
-Overture `2024-01-17-alpha.0` is now available. This release includes several incremental improvements, addition of geopolitical boundary information in the Admins Theme and expansion of GERS IDs across several themes. More information about these additions is available in the relevant sections below. 
-
-This data is formatted in the Overture Data Schema unless otherwise noted. 
-
-This data is available for use under the designated licenses for each theme. 
-
-We would like feedback on the data, its usefulness, and how it could be improved. Please use this Github repo for discussions and feedback related to this data release.
-
-Overture `2024-01-17-alpha.0` is available in GeoParquet and stored on AWS and Azure. 
+Overture `2024-01-17-alpha.0` is now available. This release includes several incremental improvements, addition of geopolitical boundary information in the Admins Theme and expansion of GERS IDs across several themes. More information about these additions is available in the relevant sections below. This data is formatted in the Overture Data Schema unless otherwise noted. This data is available for use under the designated licenses for each theme. Overture `2024-01-17-alpha.0` is available in GeoParquet and stored on AWS and Azure. 
 
 ### Changelog
 See our [changelog](https://github.com/OvertureMaps/schema/releases/tag/v0.8.0) here.
@@ -168,13 +208,11 @@ See our [changelog](https://github.com/OvertureMaps/schema/releases/tag/v0.8.0) 
 Overture `2024-01-17-alpha.0` is released in five themes. 
 
 **Buildings Theme**
-The dataset includes 2.35B conflated building footprints from OSM, Esri Community Maps, Microsoft ML Building Footprints, and Google Open Buildings.
-The order of conflation is OpenStreetMap → Esri Community Maps → high precision Google Open Buildings → Microsoft ML Building Footprints → lower precision Google Open Buildings. For example, if Esri has a building that does not exist in OSM, we take that building, then we “fill-in” the rest of the map with any ML buildings that do not intersect with either OSM or Esri.
-We use the 90% precision confidence threshold to delineate between high and lower precision for Google Open Buildings, this threshold varies per s2 cell.
-
-We've made incremental improvements to further ensure the data conforms to the buildings layer schema.
-
-3d attributes from OSM, such as roof shape, are now available.
+- The dataset includes 2.35B conflated building footprints from OSM, Esri Community Maps, Microsoft ML Building Footprints, and Google Open Buildings.
+- The order of conflation is OpenStreetMap → Esri Community Maps → high precision Google Open Buildings → Microsoft ML Building Footprints → lower precision Google Open Buildings. For example, if Esri has a building that does not exist in OSM, we take that building, then we “fill-in” the rest of the map with any ML buildings that do not intersect with either OSM or Esri.
+- We use the 90% precision confidence threshold to delineate between high and lower precision for Google Open Buildings, this threshold varies per s2 cell.
+- We've made incremental improvements to further ensure the data conforms to the buildings layer schema.
+- 3d attributes from OSM, such as roof shape, are now available.
 
 The sources of the buildings theme include OpenStreetMap, Esri Community Maps, Microsoft Building footprints, and Google Open Buildings. Some building heights have also been derived using lidar from USGS 3DEP. 
 
@@ -190,31 +228,29 @@ GERS IDs for connectors and segments should now be considered stable for future 
 Data in the Transportation theme is licensed under ODbL.
 
 **Base Theme**
-All of the features in the base theme are from OpenStreetMap, sourced via the latest Daylight Map Distribution (v1.38).
-
-Includes 43M water features, 63M land features, and 44M land use features.
-
-Most original OSM tags remain on all features. Some tags become normalized and added as top-level properties, such as the surface or wikidata tags.
+- All of the features in the base theme are from OpenStreetMap, sourced via the latest Daylight Map Distribution (v1.38).
+- Includes 43M water features, 63M land features, and 44M land use features.
+- Most original OSM tags remain on all features. Some tags become normalized and added as top-level properties, such as the surface or wikidata tags.
 
 Data in the Base theme is licensed under ODbL. 
 
 **Places Theme**
-This release has over 57M place records.
-
-The Places theme in this release includes incremental improvements to improve the accuracy and quality of the dataset.
+- This release has over 57M place records.
+- The Places theme in this release includes incremental improvements to improve the accuracy and quality of the dataset.
 
 Data in the Places theme is licensed under CDLA Permissive 2.0.
 
 **Administrative Boundaries (Admins) Theme**
-Minor improvements on second-level subdivision of countries.
-Data from OSM is updated to 15th of January. 
+- Minor improvements on second-level subdivision of countries.
+- Data from OSM is updated to 15th of January. 
+- This is first release with "geopolDisplay" property set on boundaries.
 
-This is first release with "geopolDisplay" property set on boundaries.
-
+:::note
 Known issues:
 - Second-level subdivision are still not complete world-wide, as we search for data sources that are compatible with ODbL.
-- All first-level subdivisions have type=state and all second-level subdivisions have type=county which is not always true, we plan to address this issue in following release.
+- All first-level subdivisions have type=state and all second-level subdivisions have `type=county` which is not always true, we plan to address this issue in following release.
 - We plan to use admin_level=8,9,10 to add polygons to cities, towns, villages and other localities when available depending on individual country mapping.
+:::
 
 The sources of the admin theme are OpenStreetMap and Esri. The Administrative Boundary data is in the Overture Maps data schema for Admin.
 
@@ -228,16 +264,7 @@ Data in the Admin theme is licensed under ODbL.
 
 ## **`2023-12-14-alpha.0` release**
 
-### Highlights
-Overture `2023-12-14-alpha.0` is now available. This release includes several incremental improvements, the conflation of Google Open Buildings into the Building theme and expansion of GERS IDs across several themes. More information about these additions is available in the relevant sections below. 
-
-This data is formatted in the Overture Data Schema unless otherwise noted. 
-
-This data is available for use under the designated licenses for each theme. 
-
-We would like feedback on the data, its usefulness, and how it could be improved. Please use this Github repo for discussions and feedback related to this data release.
-
-Overture Overture `2023-12-14-alpha.0` is available in cloud-native Parquet (updated to Geo Parquet format for this release) and stored on AWS and Azure. 
+Overture `2023-12-14-alpha.0` is now available. This release includes several incremental improvements, the conflation of Google Open Buildings into the Building theme and expansion of GERS IDs across several themes. More information about these additions is available in the relevant sections below. This data is formatted in the Overture Data Schema unless otherwise noted. This data is available for use under the designated licenses for each theme. Overture Overture `2023-12-14-alpha.0` is available in cloud-native Parquet (updated to Geo Parquet format for this release) and stored on AWS and Azure. 
 
 ### Changelog
 See our [changelog](https://github.com/OvertureMaps/schema/releases/tag/v0.7.0) here.
@@ -264,6 +291,7 @@ Overture `2023-12-14-alpha.0` is released in five themes.
 ``` 
 
 **Buildings Theme**
+
 The dataset includes 2.4B conflated building footprints from OSM, Esri Community Maps, Microsoft ML Building Footprints, and Google Open Buildings.
 The order of conflation is OpenStreetMap → Esri Community Maps → high precision Google Open Buildings → Microsoft ML Building Footprints → lower precision Google Open Buildings. For example, if Esri has a building that does not exist in OSM, we take that building, then we “fill-in” the rest of the map with any ML buildings that do not intersect with either OSM or Esri.
 
@@ -278,6 +306,7 @@ The sources of the buildings theme include OpenStreetMap, Esri Community Maps, M
 Data in the Buildings theme is licensed under ODbL.
 
 **Transportation Theme**
+
 - Refreshed Data to include OSM data up to Nov 27
 - Added two additional road classes for pedestrians: sidewalk and crosswalk
 - Features previously classified as footway will now be reassigned to one of: footway, sidewalk, or crosswalk
@@ -291,11 +320,13 @@ GERS ID format updated to match Schema definition
 Data in the Transportation theme is licensed under ODbL.
 
 **Base Theme**
+
 All of the features in the base theme are from OpenStreetMap, sourced via the latest Daylight Map Distribution (v1.35). Data validation improvements fixed the classification of 400k landUse features and added 620k new land features and 295k new water features. Most original OSM tags remain on all features. Some tags become normalized and added as top-level properties, such as the surface or wikidata tags.
 
 Data in the Base theme is licensed under ODbL. 
 
 **Places Theme**
+
 This release has over 57M place records.
 The Places theme in this release includes incremental improvements to improve the accuracy and quality of the dataset.
 New data has been included to improve category coverage. 
@@ -305,6 +336,7 @@ Minor updates to formatting for categories.
 Data in the Places theme is licensed under CDLA Permissive 2.0.
 
 **Administrative Boundaries (Admins) Theme**
+
 The Admins theme in this release includes only minor fix to not set adminLevel on namedLocalities
 
 Known issues:
@@ -324,7 +356,6 @@ Data in the Admin theme is licensed under ODbL.
 
 ## **`2023-11-14-alpha.0` release**
 
-### Highlights
 Overture `2023-11-14-alpha.0` is now available. This is an incremental release that includes several improvements to the data quality and coverage as well as updates for data currency. More information about these additions is available in the relevant sections below. 
 
 This data is formatted in the Overture Data Schema unless otherwise noted. 
@@ -342,6 +373,7 @@ See our [changelog](https://github.com/OvertureMaps/schema/releases/tag/v0.6.0) 
 Overture `2023-11-14-alpha.0` is released in five themes. Updated to Geo Parquet format for this release:
 
 **Transportation Theme**
+
 The Transportation theme includes the following improvements:
 - Collective OSM changes through October 15th, updated and converted to Overture’s Schema.
 - Over 1.5 million turn restrictions worldwide.
@@ -353,11 +385,13 @@ The data includes some provisional Global Entity Reference System (GERS) data wh
 Data in the Transportation theme is licensed under ODbL.
 
 **Base Theme**
+
 All of the features in the base theme are from OpenStreetMap, sourced via the Daylight Map Distribution. Most original OSM tags remain on all features. Some tags become normalized and added as top-level properties, such as the surface or wikidata tags.
 
 Data in the Base theme is licensed under ODbL. 
 
 **Buildings Theme**
+
 The dataset includes 1.4B conflated building footprints from OSM, Esri Community Maps, and Microsoft ML Building Footprints. Similar to the previous release, the order of conflation is OpenStreetMap -> Esri Community Maps -> Microsoft ML Building Footprints. For example, if Esri has a building that does not exist in OSM, we take that building, then, we “fill-in” the rest of the map with any Microsoft ML buildings that do not intersect with either OSM or Esri.
 
 We've made some incremental improvements to further ensure the data conforms to the buildings layer schema.
@@ -367,6 +401,7 @@ The sources of the buildings theme include OpenStreetMap, Microsoft Building foo
 Data in the Buildings theme is licensed under ODbL.
 
 **Places Theme**
+
 This release has over 57M place records. The Places theme in this release includes incremental improvements to improve the accuracy and quality of the dataset:
 - Corrected missing postal codes from the previous release (2023-10-19-alpha.0).
 - New data has been included to improve category coverage.  
@@ -374,14 +409,15 @@ This release has over 57M place records. The Places theme in this release includ
 Data in the Places theme is licensed under CDLA Permissive 2.0.
 
 **Administrative Boundaries (Admins) Theme**
+
 The Admins theme in this release includes several modifications to improve schema of the dataset:
 - We added ability for admins to have point and area, in future multiple areas like landmass and maritime area
-- Fixed issue with invalid format of updateTime property
+- Fixed issue with invalid format of `updateTime` property
 
 :::note
 Known issues:
 - Second-level subdivision did not undergo worldwide inspection of quality so some missing or wrong data is expected.
-- All first-level subdivisions have type=state and all second-level subdivisions have type=county which is not always true, we plan to address this issue in following releases.
+- All first-level subdivisions have `type=state` and all second-level subdivisions have `type=county` which is not always true, we plan to address this issue in following releases.
 - We plan to use admin_level=8,9,10 to add polygons to cities, towns, villages and other localities when available depending on individual country mapping.
 :::
 
@@ -397,21 +433,12 @@ Data in the Admin theme is licensed under ODbL.
 
 ## **`2023-10-19-alpha.0` release** 
 
-### Highlights
 Overture `2023-10-19-alpha.0` is now available. This release includes several improvements to the data quality and coverage as well as updates for data currency.  There are two new additions of note:
 
 - **Base Theme**: A new Base theme that provides three context data subtypes. These can be used with the other themes to allow developers to build complete maps using any Overture release.
 - **Buildings Theme**: Stable identifiers have been added to 1.6M buildings in 8 cities to demonstrate how Overture will implement stable identifiers (named Global Entity Reference System or GERS). 
 
-More information about these additions is available in the relevant sections below. 
-
-This data is formatted in the Overture Data Schema unless otherwise noted. 
-
-This data is available for use under the designated licenses for each theme. While Overture intends to release open map data on a regular cadence in the future, the date of subsequent releases has not yet been established.
-
-We would like feedback on the data, its usefulness, and how it could be improved. Please use this Github repo for discussions and feedback related to this data release.
-
-Overture `2023-10-19-alpha.0` is formatted in the Overture Maps schema described here. It is available in cloud-native Parquet and stored on AWS and Azure. 
+More information about these additions is available in the relevant sections below. This data is formatted in the Overture Data Schema unless otherwise noted. This data is available for use under the designated licenses for each theme. While Overture intends to release open map data on a regular cadence in the future, the date of subsequent releases has not yet been established. Overture `2023-10-19-alpha.0` is formatted in the Overture Maps schema described here. It is available in cloud-native Parquet and stored on AWS and Azure. 
 
 ### Changelog
 See our [changelog](https://github.com/OvertureMaps/schema/releases/tag/v0.5.0) here.
@@ -420,16 +447,18 @@ See our [changelog](https://github.com/OvertureMaps/schema/releases/tag/v0.5.0) 
 Overture `2023-10-19-alpha.0` is released in five themes.
 
 **Base Theme**
+
 The Base theme is an entirely new theme with 3 subTypes: land, landUse, and water. The overall purpose of this new theme is to allow users to create a complete map using any Overture release. Descriptions of the subTypes for Base are:
-- land: Physical representations of land surfaces. Derived from the inverse of OSM Coastlines.
-- landUse: Classifications of the human use of a section of land. Mostly derived from the key landuse in OpenStreetMap
-- water: Physical representations of inland and ocean marine surfaces. Derived from OSM Coastlines, and the keys natural and waterway in OpenStreetMap.
+- `land`: Physical representations of land surfaces. Derived from the inverse of OSM Coastlines.
+- `landUse`: Classifications of the human use of a section of land. Mostly derived from the key landuse in OpenStreetMap
+- `water`: Physical representations of inland and ocean marine surfaces. Derived from OSM Coastlines, and the keys natural and waterway in OpenStreetMap.
 
 All of the features in the base theme are from OpenStreetMap, sourced via the Daylight Map Distribution. Original OSM tags remain on all features. Some tags become top-level properties, such as the surface or wikidata tags.
 
 Data in the Base theme is licensed under ODbL. 
 
 **Buildings Theme**
+
 The dataset includes 1.39B conflated building footprints from OSM, Esri Community Maps, and Microsoft ML Building Footprints. This is an increase of ~700M building footprints from the July Alpha release by including the complete Microsoft ML Building footprint dataset.
 
 The order of conflation is OpenStreetMap > Esri Community Maps > Microsoft ML Building Footprints. For example, if Esri has a building that does not exist in OSM, we take that building, then, we "fill-in" the rest of the map with any Microsoft ML buildings that do not intersect with either OSM or Esri. 
@@ -450,18 +479,19 @@ The sources include OpenStreetMap, Microsoft Building footprints, and Esri Commu
 Data in the Buildings theme is licensed under ODbL.
 
 **Administrative Boundaries (Admins) Theme**
-The Admins theme includes multiple locality types:
-- Countries formed from OpenStreetMap relations, primarily admin_level=2, with few exceptions such as admin_level=3 French Polynesia.
-- First-level subdivisions under the country which was mapped from OpenStreetMap admin_level depending on country, in most countries admin_level=4.
-- Second-level subdivisions under the country which was mapped from OpenStreetMap admin_level depending on country, in most countries admin_level=6.
-- Cities, Town, Villages, Neighborhoods... based on place=* tag. In most cases these are just points. When relation with place=* tag exist we provide polygon geometry.
 
-It also includes administrative boundaries representing borders of countries, first-level subdivisions and second-level subdivisions. The Administrative Boundary data is in the Overture Maps data schema for Admin.
-Second-level subdivision did not undergo worldwide inspection of quality so some missing or wrong data is expected. All first-level subdivisions have `type=state` and all second-level subdivisions have `type=county` which is not always true; we plan to address this issue in future releases. We plan to use admin_level=8,9,10 to add polygons to cities, town, villages and other localities when available depending on individual country mapping.
+The Admins theme includes multiple locality types:
+- Countries formed from OpenStreetMap relations, primarily `admin_level=2`, with few exceptions such as `admin_level=3` French Polynesia.
+- First-level subdivisions under the country which was mapped from OpenStreetMap admin_level depending on country, in most countries `admin_level=4`.
+- Second-level subdivisions under the country which was mapped from OpenStreetMap `admin_level` depending on country, in most countries `admin_level=6`.
+- Cities, Town, Villages, Neighborhoods... based on `place=*` tag. In most cases these are just points. When relation with `place=*` tag exist we provide polygon geometry.
+
+It also includes administrative boundaries representing borders of countries, first-level subdivisions and second-level subdivisions. The Administrative Boundary data is in the Overture Maps data schema for Admin. Second-level subdivision did not undergo worldwide inspection of quality so some missing or wrong data is expected. All first-level subdivisions have `type=state` and all second-level subdivisions have `type=county` which is not always true; we plan to address this issue in future releases. We plan to use admin_level=8,9,10 to add polygons to cities, town, villages and other localities when available depending on individual country mapping.
 
 Data in the Admin theme is licensed under ODbL. The sources of the admin theme are OpenStreetMap and Esri. 
 
 **Places Theme**
+
 This release has over 57M place records. The Places theme in this release includes several modifications to improve the accuracy and quality of the dataset:
 - Increased deduplication on significant landmarks by revising the screening criteria for signals based on check-ins only
 - Removal of places determined to be non-existent
@@ -471,6 +501,7 @@ This release has over 57M place records. The Places theme in this release includ
 Data in the Places theme is licensed under CDLA Permissive 2.0.
 
 **Transportation Theme**
+
 The Transportation theme includes the following improvements:
 - Collective OSM changes through September 15th, updated and converted to Overture's Schema.
 - Addition of Linear Referenced features, enabling the description of properties that apply along only portions of a segment.
@@ -480,7 +511,7 @@ The Transportation theme includes the following improvements:
 
 :::note
 There are several missing properties in this data release that will be added in future releases:
-- Only includes road segments made from Ways that include a ‘highway’ tag
+- Only includes road segments made from Ways that include a `highway` tag
 - Non-geometric scoping properties are not included
 - Turn and Access restrictions are not included
 - Lane information is not included
@@ -501,31 +532,29 @@ Data in the Transportation theme is licensed under ODbL.
 
 ## **`2023-07-26-alpha.0` release**
 
-### Highlights
 Overture `2023-07-26-alpha.0` is a first release version of open map data, establishing a baseline for future releases by the Overture Maps Foundation. The data is available for use under the designated licenses for each theme.  Users should note that while Overture intends to release open map data on a regular cadence in the future, the date of subsequent releases has not been established yet.
 
 We would like feedback on the data, its usefulness and how it could be improved.  Please use this Github repo for discussions and feedback related to this data release.
 
 Overture `2023-07-26-alpha.0` is formatted in the Overture Maps schema described here. It is available in cloud-native Parquet and stored on AWS and Azure.  
 
-### Changelog
-See our [changelog](https://github.com/OvertureMaps/schema/releases/tag/v0.4.0) here.
-
 ### Theme-specific updates
 Overture `2023-07-26-alpha.0` is being released in four themes: 
 
 **Places Theme**
+
 The Places theme includes Point of Interest (POI) Data on approximately 59M places worldwide. Place records include the name, address, pin location, category and social media handles to the extent these are available.  The data also includes a confidence score for each record. The sources of the Places theme include Meta and Microsoft places data. The Places data is formated in the Overture Maps schema for Places. 
 
 Data in the Places theme is licensed under CDLA Permissive 2.0.
 
-
 **Buildings Theme**
+
 The Buildings theme includes building footprint and height data as available.  It includes approximately 785M building outlines worldwide.  The sources include OpenStreetMap, Microsoft Building footprints and Esri Community Partners. Some building heights have also been derived using lidar from USGS 3DEP. The Building data is in the Overture Maps data schema for Buildings.  
 
 Data in the Buildings theme is licensed under ODbL.
 
 **Transportation Theme**
+
 The transportation theme includes road networks data based on OpenStreetMap.  This release is a demonstration of our Shape and Connectivity model of the transportation network, and also showcases how Geometric Scoping (LR) interacts with a subset of the final properties. The data has been put into the Overture Maps data schema for transportation.  As such, the data has been re-segmented and structured with some conditional attributes. For example, scoping dimensions related to speed limits have geometric scoping when speed limits change along a road segment.
 
 :::note
@@ -542,6 +571,7 @@ There are several missing properties in this data release that will be added in 
 Data is the Transportation theme is licensed under ODbL.
 
 **Administrative Boundaries (Admins) Theme**
+
 The Admins theme includes administrative boundaries for Level 2 (country-level) and Level 4 (first-level subdivisions under the country) worldwide. Admin records include the translated names for regions in ~40 languages, Context and Sources and placeholder GERS IDs. The sources of the admin theme are Esri and TomTom. The Administrative Boundary data is in the Overture Maps data schema for Admin.
 
 :::note
@@ -554,6 +584,61 @@ Data in the Admins theme is licensed under CDLA Permissive 2.0.
 - © OpenStreetMap contributors available under the Open Database License (www.openstreetmap.org/copyright)
 - U.S. Geological Survey, 2019, USGS 3D Elevation Program Digital Elevation Program  
 - Building data © OpenStreetMap contributors, Microsoft, Esri Community Maps contributors
+
+
+## **`2023-04-02-alpha`** release
+
+Overture `2023-04-02-alpha` is a pre-release version of open map data intended primarily to demonstrate the potential and possibilities for open map data that the Overture Maps Foundation intends to pursue. It is primarily for demonstration and not as a production release. 
+
+This release is built on the Daylight Map, a distribution of OpenStreetMap that builds an OSM planet file that is quality checked for errors and vandalism. Daylight also provides additional name translations, building footprints, and other data not in OpenStreetMap in the form of “sidecar” files which add data coverage or other improvements. Overture `2023-04-02-alpha` makes substantial improvements over Daylight in several ways.
+
+**Quality Validation**
+
+Overture `2023-04-02-alpha` leverages the validation and quality checks that were introduced for the Daylight map distribution. This includes both automated and manual validation checks to detect map errors, breakage, profanity and vandalism in source data. This results in a safer version of open map data. Overture 2023-04-02-alpha uses Daylight v1.25 as a baseline. The results of these validation checks can be found in the release notes here.
+
+**Integrated Planet PBF File**
+
+Daylight introduced the notion of “sidecar” files, OSM change files that allow users to include additional data on top of the base map dataset, such as ML buildings, roads, and administrative areas. Sidecar files require additional processing and tooling in place to use and can be difficult for some users to apply. For Overture we are including all data directly in a single planet PBF file. This first release contains core basemap data along with Microsoft ML buildings, additional building heights (including on ML buildings), and additional administrative area translations all in one file. In total, we added over 177 million additional building footprints. OSM tooling that can process a PBF should be able to use this planet file seamlessly. 
+
+**New 2.5D Building Data**
+
+There are over six million new 2.5D buildings in the database. These were created using lidar data from the USGS 3D Elevation Program (3DEP) combined with open data building footprints from OpenStreetMap and Microsoft. More details are available in this Technical Spotlight. Building heights from lidar data are included in the `est_height` tag on building ways.
+
+**Normalized Building Heights**
+
+Building heights in OSM data can be specified in different conventions. Some example height tags include: `11 m`, `8.5 meters`, `353 ft`, `124 feet`, and `19’8″`. Downstream users need to be aware of these different conventions and parse them accordingly. To make it easier for data consumers, we are converting any building height value into meters and replacing it in our output. Overture users can treat height values as meters without any further parsing or logic. We omit the height value when it cannot be converted into meters – real examples include `Unknown` or `half`. While starting with building heights, we plan to provide similar normalizations over other tags in future releases.
+
+**Including Only Relevant Tags**
+
+Many OSM ingestion tools ignore tags that are not useful to rendering, routing and other applications. We remove any tags like: note:*, odbl*, gnis:*, geobase:*, KSJ2:*, yh:*, osak:*, kms:*, ngbe:*, naptan:*, CLC:*, source:*, tiger, logging*,  `source_ref`, `SK53_bulk:load`, `attribution`, `comment`, `accuracy:meters`, `sub_sea:type`, `waterway:type`, `3dshapes:ggmodelk`, `import`, `created_by`, `fixme`, `osak:identifier`, and `nysgissam:nysaddresspointid`. This removes approximately 188 million tags from the planet file which helps to reduce file size and improve processing time. We plan to expand this list and remove tags in future releases that are unnecessary for end-user applications.
+
+### Licenses
+
+All data included in Overture `2023-04-02-alpha` that is licensed under ODbL (including OpenStreetMap data) or derived from ODbL data that constitutes a “Derivative Database” (as defined under ODbL v1.0), is licensed under ODbL v1.0. Data from sidecar files which was not previously licensed under ODbL is licensed under CDLA Permissive 2.0. The geojson files which contain buildings only are licensed under ODbL v1.0.
+
+### Attribution
+- © OpenStreetMap contributors available under the Open Database License (www.openstreetmap.org/copyright)
+- U.S. Geological Survey, 2019, USGS 3D Elevation Program Digital Elevation Program  
+- Building data © OpenStreetMap contributors, Microsoft  https://github.com/microsoft/GlobalMLBuildingFootprints, Esri Community Maps contributors
+
+### Download
+Overture `2023-04-02-alpha` (89 GB) is available from both AWS and Azure at the links below. 
+
+- https://overturemaps-us-west-2.s3.amazonaws.com/release/2023-04-02-alpha/planet-2023-04-02-alpha.osm.pbf
+- https://overturemapswestus2.blob.core.windows.net/release/2023-04-02-alpha/planet-2023-04-02-alpha.osm.pbf
+
+The links below allow the download of line-delimited geojson files of the buildings-only data for each area. This data is licensed under ODbL v1.0:
+
+- Cook County, IL (133 MB)
+- Eastern MA (134 MB)
+- King County, WA (58 MB)
+- Maricopa & Pinal Counties (120 MB)
+- Orange County, FL (25 MB)
+- Santa Clara County, CA (62 MB)
+
+For each region we extracted:
+- Polygon ways with tags `building != ’no’` or `building:part != ‘no’`
+- Multipolygon relations with `building != ‘no’`
 
 
 

--- a/docs/release-notes/archived.mdx
+++ b/docs/release-notes/archived.mdx
@@ -120,9 +120,6 @@ GERS IDs for connectors and segments should be considered stable for this and fu
 - Made incremental improvements to further ensure the data conforms to the base schema.
 - Note: data in the Base theme is licensed under ODbL.
 
-### Attribution
-The data sources for each theme are cited [here](/release-notes/attribution).
-
 
 ## **`2024-02-15-alpha.0` release**
 

--- a/docs/release-notes/archived.mdx
+++ b/docs/release-notes/archived.mdx
@@ -67,7 +67,7 @@ See [here](attribution) for information about licensing and data attribution for
 - Removed `mode_not` scoping.
 
 ### Attribution
-The data sources for each theme are cited [here](/release-notes/attribution).
+The data sources for each theme are cited [here](../attribution).
 
 
 ## **`2024-03-12-alpha.0` release**

--- a/docs/release-notes/archived.mdx
+++ b/docs/release-notes/archived.mdx
@@ -30,7 +30,6 @@ In this release, we implemented a refactor of the `admins` theme called `divisio
 See our [changelog](https://github.com/OvertureMaps/schema/releases) here.
 
 ### Theme-specific updates
-See [here](attribution) for information about licensing and data attribution for each theme.
 
 **Administrative Boundaries Admins/Divisions**
 - Included OSM data up to 4/8.

--- a/docs/release-notes/archived.mdx
+++ b/docs/release-notes/archived.mdx
@@ -66,9 +66,6 @@ See [here](attribution) for information about licensing and data attribution for
 - Renamed `at` to `between` for ranged linear referencing. 
 - Removed `mode_not` scoping.
 
-### Attribution
-The data sources for each theme are cited [here](../attribution).
-
 
 ## **`2024-03-12-alpha.0` release**
 

--- a/docs/release-notes/attribution.mdx
+++ b/docs/release-notes/attribution.mdx
@@ -8,27 +8,28 @@ If you are the author of a publication or research report that uses Overture Map
 The Overture Maps Foundation does not require text attribution or an OMF logo on maps, visualizations, and graphics created with our datasets. If you would like to credit Overture Maps, we suggest: `© Overture Maps Foundation`. Some of the data sources we use in Overture Maps datasets require their own attribution, according to their licenses. See below for more information.
 
 ### Admins/Divisions
-- Data sources: © OpenStreetMap contributors available under the [Open Database License](https://www.openstreetmap.org/copyright), [geoBoundaries CC BY-4.0](https://www.geoboundaries.org/) and [Esri](https://www.esri.com/en-us/home) 
-- License: [ODbL](https://opendatacommons.org/licenses/odbl/)
+- ©OpenStreetMap contributors available under the [Open Database License](https://www.openstreetmap.org/copyright); [geoBoundaries](https://www.geoboundaries.org/) available under [CC BY-4.0](https://creativecommons.org/licenses/by/4.0/); [Esri](https://www.esri.com/en-us/home) 
+- License for theme: [ODbL](https://opendatacommons.org/licenses/odbl/)
+
 
 ### Buildings
-- Data sources: © OpenStreetMap contributors available under the [Open Database License](https://www.openstreetmap.org/copyright), [Microsoft](https://www.microsoft.com/en-us/), Esri, [Google Open Buildings (CC BY-4.0)](https://arxiv.org/abs/2107.12283) and [U.S. Geological Survey, 2019, USGS 3D Elevation Program Digital Elevation Program](https://www.usgs.gov/3d-elevation-program)
-- License: [ODbL](https://opendatacommons.org/licenses/odbl/)
+- ©OpenStreetMap contributors available under the [Open Database License](https://www.openstreetmap.org/copyright); [Microsoft](https://www.microsoft.com/en-us/); [Esri](https://www.esri.com/en-us/home); [Google Open Buildings](https://arxiv.org/abs/2107.12283) available under [CC BY-4.0](https://creativecommons.org/licenses/by/4.0/); [USGS 3D Elevation Program Digital Elevation Program](https://www.usgs.gov/3d-elevation-program)
+- License for theme: [ODbL](https://opendatacommons.org/licenses/odbl/)
 
 ### Transportation
-- Data sources: © OpenStreetMap contributors available under the [Open Database License](https://www.openstreetmap.org/copyright)
-- License: [ODbL](https://opendatacommons.org/licenses/odbl/)
+- ©OpenStreetMap contributors available under the [Open Database License](https://www.openstreetmap.org/copyright)
+- License for theme: [ODbL](https://opendatacommons.org/licenses/odbl/)
 
 ### Places
-- Data sources: Meta, Microsoft
-- License: [CDLA Permissive 2.0.](https://cdla.dev/permissive-2-0/)
+- [Meta](https://about.meta.com/); [Microsoft](https://www.microsoft.com/en-us/)
+- License for theme: [CDLA Permissive 2.0.](https://cdla.dev/permissive-2-0/)
 
 ### Base
-- Data sources: © OpenStreetMap contributors available under the [Open Database License](https://www.openstreetmap.org/copyright) and [Daylight Map Distribution v1.41](https://daylightmap.org/) 
-- License: [ODbL](https://opendatacommons.org/licenses/odbl/)
+- ©OpenStreetMap contributors available under the [Open Database License](https://www.openstreetmap.org/copyright); [Daylight Map Distribution v1.41](https://daylightmap.org/); [ESA WorldCover](https://esa-worldcover.org/en/data-access) available under [CC BY 4.0 DEED](https://creativecommons.org/licenses/by/4.0/)
+- License for theme: [ODbL](https://opendatacommons.org/licenses/odbl/) 
 
 
 
 
 
-_Rev. 2024-05-01_
+_Rev. 2024-05-15_

--- a/docs/release-notes/attribution.mdx
+++ b/docs/release-notes/attribution.mdx
@@ -8,12 +8,12 @@ If you are the author of a publication or research report that uses Overture Map
 The Overture Maps Foundation does not require text attribution or an OMF logo on maps, visualizations, and graphics created with our datasets. If you would like to credit Overture Maps, we suggest: `© Overture Maps Foundation`. Some of the data sources we use in Overture Maps datasets require their own attribution, according to their licenses. See below for more information.
 
 ### Admins/Divisions
-- ©OpenStreetMap contributors available under the [Open Database License](https://www.openstreetmap.org/copyright); [geoBoundaries](https://www.geoboundaries.org/) available under [CC BY-4.0](https://creativecommons.org/licenses/by/4.0/); [Esri](https://www.esri.com/en-us/home) 
+- ©OpenStreetMap contributors available under the [Open Database License](https://www.openstreetmap.org/copyright); [geoBoundaries](https://www.geoboundaries.org/) available under [CC BY-4.0](https://creativecommons.org/licenses/by/4.0/); [Esri Community Maps contributors](https://communitymaps.arcgis.com/home/) available under [CC BY-4.0](https://creativecommons.org/licenses/by/4.0/)
 - License for theme: [ODbL](https://opendatacommons.org/licenses/odbl/)
 
 
 ### Buildings
-- ©OpenStreetMap contributors available under the [Open Database License](https://www.openstreetmap.org/copyright); [Microsoft](https://www.microsoft.com/en-us/); [Esri](https://www.esri.com/en-us/home); [Google Open Buildings](https://arxiv.org/abs/2107.12283) available under [CC BY-4.0](https://creativecommons.org/licenses/by/4.0/); [USGS 3D Elevation Program Digital Elevation Program](https://www.usgs.gov/3d-elevation-program)
+- ©OpenStreetMap contributors available under the [Open Database License](https://www.openstreetmap.org/copyright); [Microsoft](https://www.microsoft.com/en-us/); [Esri Community Maps contributors](https://communitymaps.arcgis.com/home/) available under [CC BY-4.0](https://creativecommons.org/licenses/by/4.0/); [Google Open Buildings](https://arxiv.org/abs/2107.12283) available under [CC BY-4.0](https://creativecommons.org/licenses/by/4.0/); [USGS 3D Elevation Program Digital Elevation Program](https://www.usgs.gov/3d-elevation-program)
 - License for theme: [ODbL](https://opendatacommons.org/licenses/odbl/)
 
 ### Transportation

--- a/docs/release-notes/index.mdx
+++ b/docs/release-notes/index.mdx
@@ -58,7 +58,7 @@ See information above about the deprecation of `admins` schema and data
 
 ### Attribution
 
-You'll find information about attribution and licensing [here](/release-notes/attribution).
+You'll find information about attribution and licensing [here](attribution).
 
 
 

--- a/docs/release-notes/index.mdx
+++ b/docs/release-notes/index.mdx
@@ -3,73 +3,62 @@ description: Overture Maps Monthly Release Notes
 title: Latest
 ---
 
-## **`2024-04-16-beta.0` release**
+## **`2024-05-16-beta.0` release**
 
-### Highlights
-Here are the highlights for what's new and updated in the Overture Maps `2024-04-16-beta.0` release. The "beta" designation indicates the data and schema are largely stable. 
+Here's what's new and updated in the Overture Maps `2024-05-16-beta.0` release. The "beta" designation indicates the data and schema are largely stable. 
 
-Overture Maps `2024-04-16-beta.0` is available in GeoParquet and stored on AWS and Azure. Users can select the data of interest and download it by following the process outlined [here](https://docs.overturemaps.org/getting-data/).
-
-We encourage developers wishing to adopt Overture Maps base layers to begin evaluating and providing [feedback on the data, schema, and GERS IDs](https://github.com/OvertureMaps/data/discussions). Depending on the feedback from this release and subsequent releases, we anticipate moving to a production release in the next few months.   
+Overture Maps `2024-05-16-beta.0` is available in GeoParquet and stored on AWS and Azure. Users can select the data of interest and download it by following the process outlined [here](https://docs.overturemaps.org/getting-data/). We encourage developers wishing to adopt Overture Maps base layers to begin evaluating and providing [feedback on the data, schema, and GERS IDs](https://github.com/OvertureMaps/data/discussions). Depending on the feedback from this release and subsequent releases, we anticipate moving to a production release in the next few months.   
 
 ### Breaking changes
-We renamed the `bbox` column fields to align with the upcoming [GeoParquet](https://geoparquet.org/) 1.1 spec. 
 
-```
-minx → xmin
-miny → ymin
-maxx → xmax
-maxy → ymax
-```
+In the `buildings` theme, we promoted `class` to `subtype` and introduced new `class` values. This allows for more detail in a feature. Parking garages, for example, now have the attributes: `subtype=transportation` and `class=parking`.
 
-The fields are all now [Parquet Float (32-bit)](https://parquet.apache.org/docs/file-format/types/) where as they had previously been distributed as Double (64-bit).
 
 ### Deprecations
-In this release, we implemented a refactor of the `admins` theme called `divisions`. The `divisions` schema and data are [now available](/guides/divisions). The two themes will coexist for two subsequent releases (May 2024 and June 2024), at which point `divisions` will fully replace `admins`. More information on why we made this change [here](https://github.com/OvertureMaps/schema/discussions/117).
+Last month, we announced the deprecation of our `admins` theme and launched its replacement, `divisions`. Because of issues with missing data in `divisions`, we have extended the life of `admins`. Here is the new deprecation schedule: the two themes will coexist in the May, June, and July 2024 releases; in the August 2024 release, we will fully remove `admins` from our schema and data. More information on why we made this change [here](https://github.com/OvertureMaps/schema/discussions/117).
 
 ### Changelog
 See our [changelog](https://github.com/OvertureMaps/schema/releases) here.
 
 ### Theme-specific updates
-See [here](attribution) for information about licensing and data attribution for each theme.
 
-**Administrative Boundaries Admins/Divisions**
-- Included OSM data up to 4/8.
-- Implemented the schema for the `divisions` theme, which has a better defined schema supporting perspectives, different types of polygons, and other new features.
-- Note: see information above about the deprecation of `admins`.
+**Divisions/Admins** 
+
+- refreshed data with OpenStreetMap snap on 10 May 2024
+- populated `region` field for `division_area` type
+- populated `local_type` field `division` type
+- known issue: the `capital_division_id` field in `division` type is missing data
+
+:::warning
+See information above about the deprecation of `admins` schema and data
+:::
 
 **Base**
-- Included OSM data up to 3/16 (sourced via Daylight Map Distribution v1.44).
-- Included 46M water features, 55M land features, 40M land use features, and 48M infrastructure features.
-- Maintained the original OSM tags remain on all features.
-- Normalized and added `elevation`, `surface`, and `wikidata` as top-level properties.
+
+- added `land_cover` schema and data derived from ESA WorldCover high-resolution Earth observation imagery
+- added new subtypes in `infrastructure` type: `barrier`, `pedestrian`, `utility`, `waste_management`, `water`
+- added `min_zoom` and `max_zoom` attributes for cartographic purposes
 
 **Buildings**
-- Included OSM data up to 3/16 (sourced via Daylight Map Distribution v1.44).
-- Included 2.35B conflated building footprints from OSM, Esri Community Maps, Microsoft ML Building Footprints, and Google Open Buildings.
-- Made incremental improvements to further ensure the data conforms to the buildings layer schema.
-- Added 3d attributes from OSM, such as roof shape.
-- Note: The order of conflation is OpenStreetMap → Esri Community Maps → high precision Google Open Buildings → Microsoft ML Building Footprints → lower precision Google Open Buildings. For example, if Esri has a building that does not exist in OSM, we take that building, then we “fill-in” the rest of the map with any ML buildings that do not intersect with either OSM or Esri. We use the 90% precision confidence threshold to delineate between high and lower precision for Google Open Buildings, this threshold varies per s2 cell.
 
+- promoted `class` to `subtype` and introduced new class values for buildings. Where relevant, the class tag is the value of the building key in OSM. This allows anyone to use previous class types as subtype (backwards compatible) and introduces new class values that allow for more detail, like parking. Parking garages, for example, now have the attributes: `subtype=transportation`, `class=parking`; example of new subtypes, promoted from class: `agricultural`, `civic`, `commercial`, `education`, `entertainment`, `industrial`, `medical`, `military`, `outbuilding`, `religious`, `residential`, `service`, `transportation`
+- made incremental updates from OSM since the previous release
 
 **Places**
-- Included ~53 million place records.
-- Included stable GERS IDs propagated from the previous release; roughly 51 million of the IDs are propagated and 2 million are new.
-- Made incremental changes to improve the accuracy and quality of the dataset.
+
+- made incremental changes to improve the accuracy and quality of the dataset
 
 **Transportation**
-- Included OSM data up to 4/7.
-- Classified 12.2M segments as path.
-- Added `is_covered` flag to denote partially enclosed segments.
-- Improved scope merging; fewer access restrictions entries are now required.
-- Fixed a projection issue affecting segment length calculation and linear referencing
-- Promoted `class` to a top-level property.
-- Moved `level` property into `road` property to allow linear referencing. 84% of all segments which had previously dropped `level` will now have that information.
-- Renamed `at` to `between` for ranged linear referencing. 
-- Removed `mode_not` scoping.
+
+- added missing vehicle travel mode
+- added missing `is_covered` road flag
+- populated `is_abandoned` flag when relevant abandoned or disused tags are present
+- added OSM source ids for connectors
+- fixed null linear referencing for names in some cases
 
 ### Attribution
-The data sources for each theme are cited [here](/release-notes/attribution).
+
+You'll find information about attribution and licensing [here](/release-notes/attribution).
 
 
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -57,10 +57,18 @@ const sidebars = {
         },
         'guides/gers',
         'guides/places',
-        'guides/buildings',
+        {
+          type: 'doc',
+          id: 'guides/buildings',
+          label: 'Buildings',
+        },
         'guides/admins',
         'guides/divisions',
-        'guides/base',
+        {
+          type: 'doc',
+          id: 'guides/base',
+          label: 'Base',
+        },  
         {
           type: 'category',
           label: 'Transportation',
@@ -88,7 +96,7 @@ const sidebars = {
         'release-notes/index',
         'release-notes/archived',
         'release-notes/attribution',
-        'release-notes/breaking-changes',
+        <!--'release-notes/breaking-changes',-->
         <!--'release-notes/deprecation-notices'-->
       ]
     },


### PR DESCRIPTION
1. update release notes to include `2024-05-16-beta.0` release
2. fix formatting on archived release notes
3. updates to guides, including property tables (partially finished)