### PR TITLE
relative links allow react to do its thing

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+## Pull Request
+
+### Docs Preview:
+
+[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/<PUT THE PR # HERE>)
+
+View all staged runs:
+https://github.com/OvertureMaps/docs/actions/workflows/publish-pr-to-staging.yml

--- a/.github/workflows/publish-pr-to-staging.yml
+++ b/.github/workflows/publish-pr-to-staging.yml
@@ -45,3 +45,6 @@ jobs:
       - name: Purge CDN cache
         run: |
           aws cloudfront create-invalidation --distribution-id E3L106P8HVBE9L --paths "/how-to/pr/${{github.event.number}}/*"
+
+      - name: Publish URL
+        run: echo "### [https://dfhx9f55j8eg5.cloudfront.net/how-to/pr/${{github.event.number}}/](https://dfhx9f55j8eg5.cloudfront.net/how-to/pr/${{github.event.number}}/)" >> $GITHUB_STEP_SUMMARY

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ node_modules/
 docs/_examples/
 docs/_schema/
 docs/schema/
+docs/schema
 static/_schema/
 build/

--- a/docs/examples/build-a-map.mdx
+++ b/docs/examples/build-a-map.mdx
@@ -29,7 +29,7 @@ Overture Maps data is released in the cloud-native format [GeoParquet](https://g
 <!-- Places  -->
 <TabItem value="places" label="Places" default>
 
-The places data theme represents business and points of interest in the real world. Read more about the places data schema in the [documentation](https://docs.overturemaps.org/schema/reference/places/place).
+The places data theme represents business and points of interest in the real world. Read more about the places data schema in the [documentation](/schema/reference/places/place).
 
 1. The following DuckDB query downloads places data within a specific bounding box and writes a `GeoJSON` file.
 

--- a/docs/examples/kepler-gl.mdx
+++ b/docs/examples/kepler-gl.mdx
@@ -23,7 +23,7 @@ Here's a similar query in DuckDB's flavor of SQL that outputs a GeoJSON file.
 
 <QueryBuilder query={HyderabadBuildingsDuckDB}></QueryBuilder>
 
-## Explore the data in kepler.gl 
+## Explore the data in kepler.gl
 Drag and drop the CSV or GeoJSON file into [kepler.gl](https://kepler.gl/demo). Style the feature layer by choosing different colors based on the `primary_source` field. Then you can explore the data sources that Overture Maps conflated to create the buildings theme.
 
 ![kepler.gl example](/img/kepler-overture-hyderabad.png)

--- a/docs/examples/rapid-id.mdx
+++ b/docs/examples/rapid-id.mdx
@@ -6,7 +6,7 @@ import CodeBlock from '@theme/CodeBlock';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-In this example, we will load Overture Maps places data into Rapid so that we can visualize and inspect the geometries and their properties. 
+In this example, we will load Overture Maps places data into Rapid so that we can visualize and inspect the geometries and their properties.
 
 To open Rapid v2, navigate to [https://rapideditor.org/edit](https://rapideditor.org/edit).
 

--- a/docs/getting-data/cloud-services.mdx
+++ b/docs/getting-data/cloud-services.mdx
@@ -18,7 +18,7 @@ You can access and query Overture Maps parquet files directly in the cloud using
 
 ### 1. Add Overture as a data source
 
-Add Overture as a cross-account data source using [these instructions](https://docs.aws.amazon.com/athena/latest/ug/data-sources-glue-cross-account.html). The Catalog ID is `913550007193`. 
+Add Overture as a cross-account data source using [these instructions](https://docs.aws.amazon.com/athena/latest/ug/data-sources-glue-cross-account.html). The Catalog ID is `913550007193`.
 
   <details>
         <summary>AWS Glue Data Catalog</summary>
@@ -28,7 +28,7 @@ Add Overture as a cross-account data source using [these instructions](https://d
     </details>
 
 
-Depending on the permissions attached to your AWS user account/role, you may need to explicitly enable access to the Overture catalog. You can do that by [adding a new IAM policy](https://console.aws.amazon.com/iam/home?#/policies?type=customer)-- we suggest calling it `OvertureGlueCatalogAccess` -- with the following permissions: 
+Depending on the permissions attached to your AWS user account/role, you may need to explicitly enable access to the Overture catalog. You can do that by [adding a new IAM policy](https://console.aws.amazon.com/iam/home?#/policies?type=customer)-- we suggest calling it `OvertureGlueCatalogAccess` -- with the following permissions:
 
 <details>
   <summary>IAM policy for Overture Glue Data Catalog access</summary>
@@ -58,7 +58,7 @@ Depending on the permissions attached to your AWS user account/role, you may nee
 
 
 
-### 2. Inspect release tables 
+### 2. Inspect release tables
 
 Now each release is available as a table under the `release` database in the `overture` data source (note the `v` at the beginning of the table name). The `overture` data catalog will be updated with a new table for each new release.
 
@@ -69,7 +69,7 @@ Now each release is available as a table under the `release` database in the `ov
         </div>
     </details>
 
-   
+
 ### 3. Access data from a release table
 
 You can access Overture Maps data in a particular release like this:
@@ -82,7 +82,7 @@ You can access Overture Maps data in a particular release like this:
 
 More information on using Athena is available in the [Amazon Athena User Guide](https://docs.aws.amazon.com/athena/latest/ug/what-is.html).
 
-### Optional 
+### Optional
 
 #### Add the table directly using the DDL
 

--- a/docs/guides/admins.mdx
+++ b/docs/guides/admins.mdx
@@ -25,6 +25,6 @@ The features in the Overture Maps `admins` theme describe named localities in th
 
 ## Schema reference
 
-- [Explore the schema reference for administrative boundaries](https://docs.overturemaps.org/schema/reference/admins/administrative-boundary).
-- [Explore the schema reference for the locality feature type](https://docs.overturemaps.org/schema/reference/admins/locality).
-- [Explore the schema reference for the locality area feature type](https://docs.overturemaps.org/schema/reference/admins/locality-area).
+- [Explore the schema reference for administrative boundaries](/schema/reference/admins/administrative_boundary).
+- [Explore the schema reference for the locality feature type](/schema/reference/admins/locality).
+- [Explore the schema reference for the locality area feature type](/schema/reference/admins/locality_area).

--- a/docs/guides/base.mdx
+++ b/docs/guides/base.mdx
@@ -8,9 +8,9 @@ The Overture Maps `base` theme provides the land and water features that are nec
 
 - **`infrastructure`**: Infrastructure features such as communication towers and lines, piers, and bridges.
 - **`land`**: physical representations of land surfaces derived from the inverse of OSM Coastlines; translates natural tags from OpenStreetMap.
+- **`land_cover`**: derived from [ESA WorldCover](https://esa-worldcover.org/en), high-resolution optical Earth observation data.
 - **`land_use`**: classifications of the human use of a section of land; translates landuse tag from OpenStreetMap.
 - **`water`**: physical representations of inland and ocean marine surfaces; translates natural and waterway tags from OpenStreetMap.
-- **`land_cover`**: derived from [ESA WorldCover](https://esa-worldcover.org/en), high-resolution optical Earth observation data.
 
 ## Schema design choices
 
@@ -21,8 +21,8 @@ The Overture Maps `base` theme provides the land and water features that are nec
 
 ## Schema reference
 
-- [Explore the schema for the infrastructure feature type](https://docs.overturemaps.org/schema/reference/base/infrastructure).
-- [Explore the schema for the land feature type](https://docs.overturemaps.org/schema/reference/base/land).
-- [Explore the schema for the land use feature type](https://docs.overturemaps.org/schema/reference/base/land_use).
-- [Explore the schema for the water feature type](https://docs.overturemaps.org/schema/reference/base/water).
-- [Explore the schema for the land cover feature type](https://docs.overturemaps.org/schema/reference/base/land_cover).
+- [Explore the schema for the infrastructure feature type](/schema/reference/base/infrastructure).
+- [Explore the schema for the land feature type](/schema/reference/base/land).
+- [Explore the schema for the land cover feature type](/schema/reference/base/land_cover).
+- [Explore the schema for the land use feature type](/schema/reference/base/land_use).
+- [Explore the schema for the water feature type](/schema/reference/base/water).

--- a/docs/guides/buildings.mdx
+++ b/docs/guides/buildings.mdx
@@ -13,7 +13,7 @@ The Overture Maps `buildings` theme describes human-made structures with roofs o
 - **`building_part`**: A single part of a building. Building parts may have the same properties as buildings. A building part is associated with a parent building via a `building_id`.
 
 <details>
-        <summary>Attribute tables for the GeoParquet files in the buildings theme</summary> 
+        <summary>Attribute tables for the GeoParquet files in the buildings theme</summary>
         <div>
 <Tabs>
 <TabItem value="building" label="building" default>
@@ -21,48 +21,48 @@ The Overture Maps `buildings` theme describes human-made structures with roofs o
 | column           | type    | description |
 | ---------------- | ------- | ------------ |
 | id               | varchar | A feature ID that may be associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
-| geometry         | blob    |  A building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). MUST be a Polygon as defined by GeoJSON schema. | 
+| geometry         | blob    |  A building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). MUST be a Polygon as defined by GeoJSON schema. |
 | bbox             | struct  | Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
-| sources          | struct  | The array of source information for the properties of a given feature. Each source object lists the property in JSON Pointer notation and the dataset from which that specific value originated. | 
-| subtype          | varchar | A broad category of the building type and purpose. | 
-| names            | struct  | The name associated with the feature. The first entry in the array of names must have a "local" language. | 
-| class            | varchar | Further delineation of the building's built purpose. | 
+| sources          | struct  | The array of source information for the properties of a given feature. Each source object lists the property in JSON Pointer notation and the dataset from which that specific value originated. |
+| subtype          | varchar | A broad category of the building type and purpose. |
+| names            | struct  | The name associated with the feature. The first entry in the array of names must have a "local" language. |
+| class            | varchar | Further delineation of the building's built purpose. |
 | level            | integer | The building feature's Z-order, i.e., stacking order. A Z-order of 0 is ground level. |
-| has_parts        | boolean | Flag indicating whether the building has parts. | 
-| height           | double  | Height of the building or part in meters. The height is the distance from the lowest point to the highest point. | 
-| num_floors       | integer | Number of above-ground floors of the building or part. | 
-| min_height       | double  | The height of the bottom part of building in meters. Used if a building or part of building starts above the ground level. | 
-| min_floor        | integer | The "start" floor of a building or building part. Indicates that the building or part is "floating" and its bottom-most floor is above ground level, usually because it is part of a larger building in which some parts do reach ground level. | 
-| facade_color     | varchar | The color (name or color triplet) of the facade of a building or building part in hexadecimal. | 
-| facade_material  | varchar | The outer surface material of building facade. | 
-| roof_material    | varchar | The outermost material of the roof. | 
-| roof_shape       | varchar | The shape of the roof. | 
-| roof_direction   | double  | Bearing of the roof ridge line. | 
+| has_parts        | boolean | Flag indicating whether the building has parts. |
+| height           | double  | Height of the building or part in meters. The height is the distance from the lowest point to the highest point. |
+| num_floors       | integer | Number of above-ground floors of the building or part. |
+| min_height       | double  | The height of the bottom part of building in meters. Used if a building or part of building starts above the ground level. |
+| min_floor        | integer | The "start" floor of a building or building part. Indicates that the building or part is "floating" and its bottom-most floor is above ground level, usually because it is part of a larger building in which some parts do reach ground level. |
+| facade_color     | varchar | The color (name or color triplet) of the facade of a building or building part in hexadecimal. |
+| facade_material  | varchar | The outer surface material of building facade. |
+| roof_material    | varchar | The outermost material of the roof. |
+| roof_shape       | varchar | The shape of the roof. |
+| roof_direction   | double  | Bearing of the roof ridge line. |
 | roof_orientation | varchar | Orientation of the roof shape relative to the footprint shape. Either "along" or "across." |
-| roof_color       | varchar |  The color (name or color triplet) of the roof of a building or building part in hexadecimal. | 
+| roof_color       | varchar |  The color (name or color triplet) of the roof of a building or building part in hexadecimal. |
 
 </TabItem>
 <TabItem value="building_part" label="building_part" default>
 | column           | type    | description |
 | ---------------- | ------- | ------------ |
 | id               | varchar | A feature ID that may be associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
-| geometry         | blob    |  A building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). MUST be a Polygon as defined by GeoJSON schema. | 
+| geometry         | blob    |  A building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). MUST be a Polygon as defined by GeoJSON schema. |
 | bbox             | struct  | Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
-| sources          | struct  | The array of source information for the properties of a given feature. Each source object lists the property in JSON Pointer notation and the dataset from which that specific value originated. | 
-| names            | struct  | The name associated with the feature. The first entry in the array of names must have a "local" language. | 
-| class            | varchar | Further delineation of the building's built purpose. | 
+| sources          | struct  | The array of source information for the properties of a given feature. Each source object lists the property in JSON Pointer notation and the dataset from which that specific value originated. |
+| names            | struct  | The name associated with the feature. The first entry in the array of names must have a "local" language. |
+| class            | varchar | Further delineation of the building's built purpose. |
 | level            | integer | The building feature's Z-order, i.e., stacking order. A Z-order of 0 is ground level. |
-| height           | double  | Height of the building or part in meters. The height is the distance from the lowest point to the highest point. | 
-| num_floors       | integer | Number of above-ground floors of the building or part. | 
-| min_height       | double  | The height of the bottom part of building in meters. Used if a building or part of building starts above the ground level. | 
-| min_floor        | integer | The "start" floor of a building or building part. Indicates that the building or part is "floating" and its bottom-most floor is above ground level, usually because it is part of a larger building in which some parts do reach ground level. | 
-| facade_color     | varchar | The color (name or color triplet) of the facade of a building or building part in hexadecimal. | 
-| facade_material  | varchar | The outer surface material of building facade. | 
-| roof_material    | varchar | The outermost material of the roof. | 
-| roof_shape       | varchar | The shape of the roof. | 
-| roof_direction   | double  | Bearing of the roof ridge line. | 
+| height           | double  | Height of the building or part in meters. The height is the distance from the lowest point to the highest point. |
+| num_floors       | integer | Number of above-ground floors of the building or part. |
+| min_height       | double  | The height of the bottom part of building in meters. Used if a building or part of building starts above the ground level. |
+| min_floor        | integer | The "start" floor of a building or building part. Indicates that the building or part is "floating" and its bottom-most floor is above ground level, usually because it is part of a larger building in which some parts do reach ground level. |
+| facade_color     | varchar | The color (name or color triplet) of the facade of a building or building part in hexadecimal. |
+| facade_material  | varchar | The outer surface material of building facade. |
+| roof_material    | varchar | The outermost material of the roof. |
+| roof_shape       | varchar | The shape of the roof. |
+| roof_direction   | double  | Bearing of the roof ridge line. |
 | roof_orientation | varchar | Orientation of the roof shape relative to the footprint shape. Either "along" or "across." |
-| roof_color       | varchar |  The color (name or color triplet) of the roof of a building or building part in hexadecimal. |  
+| roof_color       | varchar |  The color (name or color triplet) of the roof of a building or building part in hexadecimal. |
 | building_id      | varchar | The building ID to which this part belongs.|
 
 </TabItem>
@@ -75,6 +75,5 @@ The Overture Maps `buildings` theme describes human-made structures with roofs o
 
 ## Schema reference
 
-- [Explore the schema reference for the building feature type](https://docs.overturemaps.org/schema/reference/buildings/building).
-- [Explore the schema reference for the building part feature type](https://docs.overturemaps.org/schema/reference/buildings/building_part).
-
+- [Explore the schema reference for the building feature type](/schema/reference/buildings/building).
+- [Explore the schema reference for the building part feature type](/schema/reference/buildings/building_part).

--- a/docs/guides/divisions.mdx
+++ b/docs/guides/divisions.mdx
@@ -20,6 +20,6 @@ The Overture Maps `divisions` theme includes features that represent human settl
 
 ## Schema reference
 
-- [Explore the schema reference for the `boundary` feature type](https://docs.overturemaps.org/schema/reference/divisions/boundary).
-- [Explore the schema reference for the `division` feature type](https://docs.overturemaps.org/schema/reference/divisions/division).
-- [Explore the schema reference for the `division_area` feature type](https://docs.overturemaps.org/schema/reference/divisions/division_area).
+- [Explore the schema reference for the `boundary` feature type](/schema/reference/divisions/boundary).
+- [Explore the schema reference for the `division` feature type](/schema/reference/divisions/division).
+- [Explore the schema reference for the `division_area` feature type](/schema/reference/divisions/division_area).

--- a/docs/guides/places.mdx
+++ b/docs/guides/places.mdx
@@ -8,8 +8,8 @@ The Overture Maps `places` theme contains datasets with point representations of
 
 ## Key schema design choices
 
-- **Extensible attributes.** Points of interest include basic attributes like phone, mail, website, and brand. Attributes currently not covered in the official schema release are allowed to exist with a prefix or `ext` in their name. 
-- **Controlled categories.** Overture Maps has created a taxonomy that allows for the transformation of different hierarchical and non-hierarchical categorization systems to the Overture categorization system. 
+- **Extensible attributes.** Points of interest include basic attributes like phone, mail, website, and brand. Attributes currently not covered in the official schema release are allowed to exist with a prefix or `ext` in their name.
+- **Controlled categories.** Overture Maps has created a taxonomy that allows for the transformation of different hierarchical and non-hierarchical categorization systems to the Overture categorization system.
 
 ## Schema reference
-[Explore the schema for the place feature type](https://docs.overturemaps.org/schema/reference/places/place).
+[Explore the schema for the place feature type](/schema/reference/places/place).

--- a/docs/guides/transportation.mdx
+++ b/docs/guides/transportation.mdx
@@ -50,5 +50,6 @@ travel mode which can be used as a way of controlling the scope of scoped
 and rule-based properties. Read more about the travel modes concept and how travel modes interact with other scoping properties on the [travel modes](/schema/attributes/transportation/travel-modes) page.
 
 ## Schema reference
-- [Explore the schema for the segment feature type](/schema/reference/transportation/segment) 
+
+- [Explore the schema for the segment feature type](/schema/reference/transportation/segment)
 - [Explore the schema for the connector feature type](/schema/reference/transportation/connector)


### PR DESCRIPTION
Replaced all instances of `https://docs.overturemaps.org/` with `/` to enforce relative links in place of absolute links.

When `/schema` was served separately, we needed these absolute links. Now that it all builds and plays nicely together, we can go back to relative links which allows react to pre-fetch, giving us better site performance.

https://dfhx9f55j8eg5.cloudfront.net/how-to/pr/49/

Also updates the github actions so that the link is published on the summary page (https://github.com/OvertureMaps/docs/actions/runs/9297762129)