### PR TITLE
Create MIT LICENSE for docs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Overture Maps
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## What's in this PR?
This PR adds an MIT license to the Overture Maps documentation project. While technically a "non-software" project, the docs contain enough code snippets and code examples to warrant an MIT license. This is consistent with the license we have assigned to Overture's other open-source developer tools -- [overturemaps-py](https://github.com/OvertureMaps/overturemaps-py), [transportation-splitter](https://github.com/OvertureMaps/transportation-splitter), [overture-tiles](https://github.com/OvertureMaps/overture-tiles), and [explore](https://github.com/OvertureMaps/io-site). 

From https://choosealicense.com/non-software/:
```
Documentation
Any open source software license or open license for media (see above) also applies to software documentation. If you use different licenses for your software and its documentation, be sure to specify that source code examples in the documentation are also licensed under the software license.
```
View all staged runs:
https://github.com/OvertureMaps/docs/actions/workflows/publish-pr-to-staging.yml
