### PR TITLE
Remove "Transportation Guide"

### DIFF
--- a/docs/guides/transportation.mdx
+++ b/docs/guides/transportation.mdx
@@ -1,5 +1,5 @@
 ---
-title: Transportation Guide
+title: Transportation
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';


### PR DESCRIPTION
Just call it "Transportation" like the other themes

## Pull Request

### Docs Preview:

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/how-to/pr/<PUT THE PR # HERE>)

View all staged runs:
https://github.com/OvertureMaps/docs/actions/workflows/publish-pr-to-staging.yml

Before:
<img width="373" alt="Screenshot 2024-12-04 at 11 23 59 AM" src="https://github.com/user-attachments/assets/a7e6990c-9a4c-490d-a09a-b509e00fb8de">

After:
<img width="347" alt="Screenshot 2024-12-04 at 11 23 54 AM" src="https://github.com/user-attachments/assets/f16f1431-75a4-435e-8c90-101cf58ce941">

