### PR TITLE
January 2025 release notes and updates

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -21,7 +21,7 @@ const config = {
   favicon: 'img/favicon.png',
 
   customFields: {
-    overtureRelease: '2024-12-18.0',
+    overtureRelease: '2025-01-22.0',
   },
 
   future: {

--- a/release-blog/2024/2024-12-18.0.mdx
+++ b/release-blog/2024/2024-12-18.0.mdx
@@ -1,6 +1,6 @@
 ---
 title: 2024-12-18.0
-slug: latest
+slug: 2024-12-18.0
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';

--- a/release-blog/2025/2025-01-22.0.mdx
+++ b/release-blog/2025/2025-01-22.0.mdx
@@ -56,7 +56,7 @@ The base, buildings, divisions, places, and transportation themes are in GA. The
 - refreshed data on 17 January 2025
 
 ### Places
-A statement from the Places engineering team: _“The places data has remained unchanged since the September 2024 release while we work on substantial pipeline upgrades. We anticipate releasing a new dataset in the coming months with new sources of data and many bug fixes.”_
+A statement from the Places engineering team: _“The places data has remained unchanged since the September 2024 release while we work on substantial pipeline upgrades. We anticipate releasing a new dataset in the coming months.”_
 
 ### Transportation
 - added approximately 4000km of new TomTom-sourced roads in the US
@@ -76,7 +76,7 @@ s3://overturemaps-us-west-2/changelog/2025-01-22.0
 You can find more information about [the GERS Changelog in our documentation](https://docs.overturemaps.org/gers/changelog/).
 
 ## Schema changelog
-The changelog for Overture schema `v1.5.0` is [here](https://github.com/OvertureMaps/schema/releases/tag/v1.4.0). 
+The changelog for Overture schema `v1.5.0` is [here](https://github.com/OvertureMaps/schema/releases). 
 
 ## Attribution  
 

--- a/release-blog/2025/2025-01-22.0.mdx
+++ b/release-blog/2025/2025-01-22.0.mdx
@@ -47,7 +47,7 @@ The base, buildings, divisions, places, and transportation themes are in GA. The
 - made minor fixes and updates
 
 ### Buildings
-- added 228.5M buildings from Zenodo
+- added 228.5M buildings from a [new ML-derived building dataset of East Asian countries](https://zenodo.org/records/8174931)
 - made minor fixes and updates
 
 ### Divisions

--- a/release-blog/2025/2025-01-22.0.mdx
+++ b/release-blog/2025/2025-01-22.0.mdx
@@ -1,0 +1,83 @@
+---
+title: 2025-01-22.0
+slug: latest
+---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import QueryBuilder from '@site/src/components/queryBuilder';
+
+## Overview
+
+**The `2025-01-22.0` release of Overture data and `v1.5.0` of the Overture schema are now available.** 
+
+The datasets are available as GeoParquet files stored on both AWS and Azure. The release paths are:
+
+#### Microsoft Azure:
+```
+wasbs://release@overturemapswestus2.blob.core.windows.net/2025-01-22.0
+```
+
+#### Amazon S3:
+```
+s3://overturemaps-us-west-2/release/2025-01-22.0
+```
+
+You can access the datasets by following the process outlined [here](/getting-data). We encourage you to ask questions, report bugs, and provide feedback via our [data](https://github.com/OvertureMaps/data) and [schema](https://github.com/OvertureMaps/schema) repositories on GitHub. If you have a suggestion for a new dataset or if you have data you'd like to contribute to Overture, you can email us at data@overturemaps.org. We’d love to hear from you.
+
+
+## Breaking changes
+
+None. 
+
+## Deprecations
+
+ None.
+
+## Theme-specific updates
+
+:::info
+The base, buildings, divisions, places, and transportation themes are in GA. The addresses theme is in alpha. 
+:::
+
+### Addresses
+- added five new data sources in Taiwan
+- made minor fixes and updates
+
+### Base
+
+
+### Buildings
+- added xxx buildings from Zenodo
+
+### Divisions
+- new cartography column in the schema that has not yet been populated with data
+- added `is_land` and `is_territorial` properties to `division_area` and `division_boundary` feature types
+- refreshed data on 17 January 2025
+
+### Places
+A statement from the Places engineering team: “The places data has remained unchanged since the September 2024 release while we work on substantial pipeline upgrades. We anticipate releasing a new dataset in the coming months with new sources of data and many bug fixes.”
+
+### Transportation
+- added 4000 km of new non-OSM roads from TomTom
+- refreshed data on 
+  
+
+## Global Entity Reference System (GERS) changelog
+
+The GERS changelog captures any changes in Overture features between this release and the previous release. The changelog is available as Parquet files &mdash; partitioned by theme, type, and change type &mdash; at the following locations on Azure and AWS:
+
+```
+wasbs://changelog@overturemapswestus2.blob.core.windows.net/2025-01-22.0
+```
+```
+s3://overturemaps-us-west-2/changelog/2025-01-22.0
+```
+
+You can find more information about [the GERS Changelog in our documentation](https://docs.overturemaps.org/gers/changelog/).
+
+## Schema changelog
+The changelog for Overture schema `v1.5.0` is [here](https://github.com/OvertureMaps/schema/releases/tag/v1.4.0). 
+
+## Attribution  
+
+You'll find information about attribution and licensing [here](/attribution).

--- a/release-blog/2025/2025-01-22.0.mdx
+++ b/release-blog/2025/2025-01-22.0.mdx
@@ -31,7 +31,7 @@ None.
 
 ## Deprecations
 
- None.
+None.
 
 ## Theme-specific updates
 
@@ -44,10 +44,11 @@ The base, buildings, divisions, places, and transportation themes are in GA. The
 - made minor fixes and updates
 
 ### Base
-
+- made minor fixes and updates
 
 ### Buildings
-- added xxx buildings from Zenodo
+- added 228.5M buildings from Zenodo
+- made minor fixes and updates
 
 ### Divisions
 - new cartography column in the schema that has not yet been populated with data
@@ -55,13 +56,12 @@ The base, buildings, divisions, places, and transportation themes are in GA. The
 - refreshed data on 17 January 2025
 
 ### Places
-A statement from the Places engineering team: “The places data has remained unchanged since the September 2024 release while we work on substantial pipeline upgrades. We anticipate releasing a new dataset in the coming months with new sources of data and many bug fixes.”
+A statement from the Places engineering team: _“The places data has remained unchanged since the September 2024 release while we work on substantial pipeline upgrades. We anticipate releasing a new dataset in the coming months with new sources of data and many bug fixes.”_
 
 ### Transportation
-- added 4000 km of new non-OSM roads from TomTom
-- refreshed data on 
+- added approximately 4000km of new TomTom-sourced roads in the US
+- refreshed data on 18 December 2024
   
-
 ## Global Entity Reference System (GERS) changelog
 
 The GERS changelog captures any changes in Overture features between this release and the previous release. The changelog is available as Parquet files &mdash; partitioned by theme, type, and change type &mdash; at the following locations on Azure and AWS:


### PR DESCRIPTION
## What's in this PR?
- release notes for `2025-01-22.0` of the data and `v1.5.0` of the Overture schema
- updated config file with new release path

### Docs Preview:

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/how-to/pr/147/release/latest/)

View all staged runs:
https://github.com/OvertureMaps/docs/actions/workflows/publish-pr-to-staging.yml
