### PR TITLE
Fix fused run link

### DIFF
--- a/docs/getting-data/fused.mdx
+++ b/docs/getting-data/fused.mdx
@@ -38,7 +38,7 @@ bbox = gpd.GeoDataFrame(
 ```
 
 ### Run the Overture UDF
-We may run the Fused Overture UDF with `fused.run` (see more about `fused.run` on the [Fused docs](https://docs.fused.io/core-concepts/run/#fusedrun)). We specify the area to load data with the `bbox` parameter. The UDF also provides optional parameters to select specific Overture releases, datasets, and columns - giving you flexibility to fetch only the data you need.
+We may run the Fused Overture UDF with `fused.run` (see more about `fused.run` on the [Fused docs](https://docs.fused.io/core-concepts/run-udfs/)). We specify the area to load data with the `bbox` parameter. The UDF also provides optional parameters to select specific Overture releases, datasets, and columns - giving you flexibility to fetch only the data you need.
 
 
 <Tabs queryString="fused-run">


### PR DESCRIPTION
The link to Fused run documentation was broken. I fixed the link.

## Pull Request

### Docs Preview:

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/how-to/pr/<PUT THE PR # HERE>)

View all staged runs:
https://github.com/OvertureMaps/docs/actions/workflows/publish-pr-to-staging.yml
