### PR TITLE
add gtag from LF account

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -132,6 +132,10 @@ const config = {
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
+        gtag: {
+        trackingID: 'G-JBXK7VCHV4',
+        anonymizeIP: true, 
+        },
       }),
     ],
   ],


### PR DESCRIPTION
## What's in this PR?
Add gtag to preset-classic config: https://github.com/facebook/docusaurus/pull/5832

### Docs Preview:

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/how-to/pr/<PUT THE PR # HERE>)

View all staged runs:
https://github.com/OvertureMaps/docs/actions/workflows/publish-pr-to-staging.yml
