### PR TITLE
Updated theme guides

### DIFF
--- a/docs/guides/addresses.mdx
+++ b/docs/guides/addresses.mdx
@@ -43,43 +43,43 @@ An `address` is a feature type that represents a physical place through a series
 	<summary>Address counts, per country</summary>
 <div>
 
-| country	| address count |
-| --------- | ------------- |
-| AT		|     2,492,155 |
-| AU		|    15,706,733 |
-| BE		|     6,878,909 |
-| BR		|    89,899,299 |
-| CA		|    17,062,677 |
-| CH		|     3,255,937 |
-| CL		|     4,219,970 |
-| CO		|     7,786,046 |
-| CZ		|     2,994,390 |
-| DE		|    15,847,817 |
-| DK		|     3,928,962 |
-| EE		|     2,214,971 |
-| ES		|    13,188,482 |
-| FI		|     3,748,102 |
-| FR		|    26,054,056 |
-| HK		|       182,155 |
-| HR		|     1,674,127 |
-| IS		|       136,726 |
-| IT		|    25,949,445 |
-| JP		|    19,576,027 |
-| LI		|        12,867 |
-| LT		|     1,036,251 |
-| LU		|       164,415 |
-| LV		|       544,380 |
-| MX		|    30,278,896 |
-| NL		|     9,869,902 |
-| NO		|     2,571,756 |
-| NZ		|     2,378,530 |
-| PL		|     7,669,619 |
-| PT		|     5,676,331 |
-| SI		|       576,419 |
-| SK		|     1,630,271 |
-| TW		|     9,505,574 |
-| US		|   110,994,780 |
-| UY		|     1,059,695 |
+| country | address count |
+| --- | --- |
+| AT |     2,492,155 |
+| AU |    15,706,733 |
+| BE |     6,878,909 |
+| BR |    89,899,299 |
+| CA |    17,062,677 |
+| CH |     3,255,937 |
+| CL |     4,219,970 |
+| CO |     7,786,046 |
+| CZ |     2,994,390 |
+| DE |    15,847,817 |
+| DK |     3,928,962 |
+| EE |     2,214,971 |
+| ES |    13,188,482 |
+| FI |     3,748,102 |
+| FR |    26,054,056 |
+| HK |       182,155 |
+| HR |     1,674,127 |
+| IS |       136,726 |
+| IT |    25,949,445 |
+| JP |    19,576,027 |
+| LI |        12,867 |
+| LT |     1,036,251 |
+| LU |       164,415 |
+| LV |       544,380 |
+| MX |    30,278,896 |
+| NL |     9,869,902 |
+| NO |     2,571,756 |
+| NZ |     2,378,530 |
+| PL |     7,669,619 |
+| PT |     5,676,331 |
+| SI |       576,419 |
+| SK |     1,630,271 |
+| TW |     9,505,574 |
+| US |   110,994,780 |
+| UY |     1,059,695 |
 
 </div>
 </details>
@@ -90,23 +90,23 @@ An `address` is a feature type that represents a physical place through a series
 	<summary>Schema for the GeoParquet files in the addresses theme</summary>
 <div>
 
-| column                | type		| description |
-| --------------------- | --------- | ----------- |
-| id					| string	| A feature ID. This may be an ID associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
-| geometry              | binary	| A building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). MUST be a Polygon as defined by GeoJSON schema. |
-| bbox                  | struct	| Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
-| country				| string	| ISO 3166-1 alpha-2 country code of the country or country-like entity, that this address represents or belongs to. |
-| postcode				| string	| The postcode for the address. |
-| street				| string	| The street name associated with this address. The street name can include the street "type" or street suffix, e.g., Main Street. Ideally this is fully spelled out and not abbreviated but we acknowledge that many address datasets abbreviate the street name so it is acceptable. |
-| number				| string	| The house number for this address. This field may not strictly be a number. Values such as "74B", "189 1/2", "208.5" are common as the number part of an address and they are not part of the "unit" of this address. |
-| unit					| string	| The suite/unit/apartment/floor number. |
-| address_levels		| array		| The administrative levels present in an address. The number of values in this list and their meaning is country-dependent. For example, in the United States we expect two values: the state and the municipality. In other countries there might be only one. Other countries could have three or more. The array is ordered with the highest levels first. |
-| postal_city			| string	| In some countries or regions, a mailing address may need to specify a different city name than the city that actually contains the address coordinates. This optional field can be used to specify the alternate city name to use. |
-| version				| boolean	| Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
-| sources				| array		| The array of source information for the properties of a given feature, with each entry being a source object which lists the property in JSON Pointer notation and the dataset that specific value came from. All features must have a root level source which is the default source if a specific property's source is not specified. |
-| filename				| string	| Name of the file being queried. |
-| theme					| string	| Name of the Overture theme being queried. |
-| type					| string	| Name of the Overture feature type being queried. |
+| column | type | description |
+| --- | --- | --- |
+| id | string | A feature ID. This may be an ID associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
+| geometry | binary | A building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). MUST be a Polygon as defined by GeoJSON schema. |
+| bbox | struct | Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
+| country | string | ISO 3166-1 alpha-2 country code of the country or country-like entity, that this address represents or belongs to. |
+| postcode | string | The postcode for the address. |
+| street | string | The street name associated with this address. The street name can include the street "type" or street suffix, e.g., Main Street. Ideally this is fully spelled out and not abbreviated but we acknowledge that many address datasets abbreviate the street name so it is acceptable. |
+| number | string | The house number for this address. This field may not strictly be a number. Values such as "74B", "189 1/2", "208.5" are common as the number part of an address and they are not part of the "unit" of this address. |
+| unit | string | The suite/unit/apartment/floor number. |
+| address_levels | array | The administrative levels present in an address. The number of values in this list and their meaning is country-dependent. For example, in the United States we expect two values: the state and the municipality. In other countries there might be only one. Other countries could have three or more. The array is ordered with the highest levels first. |
+| postal_city | string | In some countries or regions, a mailing address may need to specify a different city name than the city that actually contains the address coordinates. This optional field can be used to specify the alternate city name to use. |
+| version | boolean | Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
+| sources | array | The array of source information for the properties of a given feature, with each entry being a source object which lists the property in JSON Pointer notation and the dataset that specific value came from. All features must have a root level source which is the default source if a specific property's source is not specified. |
+| filename | string | Name of the file being queried. |
+| theme | string | Name of the Overture theme being queried. |
+| type | string | Name of the Overture feature type being queried. |
 
 </div>
 </details>
@@ -115,8 +115,8 @@ An `address` is a feature type that represents a physical place through a series
 
 Overture's addresses theme data is freely available on both Amazon S3 and Microsoft Azure Blob Storage at these locations:
 
-| Provider | Location |
-| -------- | -------- |
+| provider | location |
+| --- | --- |
 | Amazon S3 | <QueryBuilder query="s3://overturemaps-us-west-2/release/__OVERTURE_RELEASE/theme=addresses/type=address/*" language="text"></QueryBuilder> |
 | Azure Blob Storage | <QueryBuilder query="https://overturemapswestus2.blob.core.windows.net/release/__OVERTURE_RELEASE/theme=addresses/type=address/*" language="text"></QueryBuilder> |
 

--- a/docs/guides/addresses.mdx
+++ b/docs/guides/addresses.mdx
@@ -41,69 +41,74 @@ An `address` is a feature type that represents a physical place through a series
 
 <details>
 	<summary>Counts, per country, of the address feature type</summary>
-| Country | Address Count |
-| -------- | -------- |
-| AT |      2,492,155 |
-| AU |     15,706,733 |
-| BE |      6,878,909 |
-| BR |     89,899,299 |
-| CA |     17,062,677 |
-| CH |      3,255,937 |
-| CL |      4,219,970 |
-| CO |      7,786,046 |
-| CZ |      2,994,390 |
-| DE |     15,847,817 |
-| DK |      3,928,962 |
-| EE |      2,214,971 |
-| ES |     13,188,482 |
-| FI |      3,748,102 |
-| FR |     26,054,056 |
-| HK |        182,155 |
-| HR |      1,674,127 |
-| IS |        136,726 |
-| IT |     25,949,445 |
-| JP |     19,576,027 |
-| LI |         12,867 |
-| LT |      1,036,251 |
-| LU |        164,415 |
-| LV |        544,380 |
-| MX |     30,278,896 |
-| NL |      9,869,902 |
-| NO |      2,571,756 |
-| NZ |      2,378,530 |
-| PL |      7,669,619 |
-| PT |      5,676,331 |
-| SI |        576,419 |
-| SK |      1,630,271 |
-| TW |      9,505,574 |
-| US |    110,994,780 |
-| UY |      1,059,695 |
+<div>
+
+| country	| address count |
+| --------- | ------------- |
+| AT		|     2,492,155 |
+| AU		|    15,706,733 |
+| BE		|     6,878,909 |
+| BR		|    89,899,299 |
+| CA		|    17,062,677 |
+| CH		|     3,255,937 |
+| CL		|     4,219,970 |
+| CO		|     7,786,046 |
+| CZ		|     2,994,390 |
+| DE		|    15,847,817 |
+| DK		|     3,928,962 |
+| EE		|     2,214,971 |
+| ES		|    13,188,482 |
+| FI		|     3,748,102 |
+| FR		|    26,054,056 |
+| HK		|       182,155 |
+| HR		|     1,674,127 |
+| IS		|       136,726 |
+| IT		|    25,949,445 |
+| JP		|    19,576,027 |
+| LI		|        12,867 |
+| LT		|     1,036,251 |
+| LU		|       164,415 |
+| LV		|       544,380 |
+| MX		|    30,278,896 |
+| NL		|     9,869,902 |
+| NO		|     2,571,756 |
+| NZ		|     2,378,530 |
+| PL		|     7,669,619 |
+| PT		|     5,676,331 |
+| SI		|       576,419 |
+| SK		|     1,630,271 |
+| TW		|     9,505,574 |
+| US		|   110,994,780 |
+| UY		|     1,059,695 |
+
+</div>
 </details>
 
-### Data columns
-
-The addresses GeoParquet file contains the following properties:
+## Understanding the parquet files
 
 <details>
-    <summary>Schema for the GeoParquet files in the addresses theme</summary>
+	<summary>Schema for the GeoParquet files in the addresses theme</summary>
+<div>
 
-| Property Name | Type | Description |
-| -------- | -------- | ------- |
-| **id** |string | A feature ID. This may be an ID associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS.
-| **geometry** | blob | A WKB representation of the entity's geometry - a Point, Polygon, MultiPolygon, or LineString.
-| **bbox** | array | The bounding box of an entity's geometry, represented with float values, in a `xmin, xmax, ymin, ymax` format.
-| **country** | string | ISO 3166-1 alpha-2 country code of the country or country-like entity, that this address represents or belongs to.
-| **postcode** | string | The postcode for the address.
-| **street** | string | The street name associated with this address. The street name can include the street "type" or street suffix, e.g., Main Street. Ideally this is fully spelled out and not abbreviated but we acknowledge that many address datasets abbreviate the street name so it is acceptable.
-| **number** | string | The house number for this address. This field may not strictly be a number. Values such as "74B", "189 1/2", "208.5" are common as the number part of an address and they are not part of the "unit" of this address.
-| **unit** | string | The suite/unit/apartment/floor number.
-| **address_levels** | array | The administrative levels present in an address. The number of values in this list and their meaning is country-dependent. For example, in the United States we expect two values: the state and the municipality. In other countries there might be only one. Other countries could have three or more. The array is ordered with the highest levels first.
-| **postal_city** | string | In some countries or regions, a mailing address may need to specify a different city name than the city that actually contains the address coordinates. This optional field can be used to specify the alternate city name to use.
-| **version** | integer | Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed.
-| **sources** | array | The array of source information for the properties of a given feature, with each entry being a source object which lists the property in JSON Pointer notation and the dataset that specific value came from. All features must have a root level source which is the default source if a specific property's source is not specified.
-| **filename** | string | Name of the S3 file being queried.
-| **theme** | string | Name of the Overture theme being queried.
-| **type** |  string | Name of the Overture feature type being queried.
+| column                | type		| description |
+| --------------------- | --------- | ----------- |
+| id					| string	| A feature ID. This may be an ID associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
+| geometry              | binary	| A building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). MUST be a Polygon as defined by GeoJSON schema. |
+| bbox                  | struct	| Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
+| country				| string	| ISO 3166-1 alpha-2 country code of the country or country-like entity, that this address represents or belongs to. |
+| postcode				| string	| The postcode for the address. |
+| street				| string	| The street name associated with this address. The street name can include the street "type" or street suffix, e.g., Main Street. Ideally this is fully spelled out and not abbreviated but we acknowledge that many address datasets abbreviate the street name so it is acceptable. |
+| number				| string	| The house number for this address. This field may not strictly be a number. Values such as "74B", "189 1/2", "208.5" are common as the number part of an address and they are not part of the "unit" of this address. |
+| unit					| string	| The suite/unit/apartment/floor number. |
+| address_levels		| array		| The administrative levels present in an address. The number of values in this list and their meaning is country-dependent. For example, in the United States we expect two values: the state and the municipality. In other countries there might be only one. Other countries could have three or more. The array is ordered with the highest levels first. |
+| postal_city			| string	| In some countries or regions, a mailing address may need to specify a different city name than the city that actually contains the address coordinates. This optional field can be used to specify the alternate city name to use. |
+| version				| boolean	| Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
+| sources				| array		| The array of source information for the properties of a given feature, with each entry being a source object which lists the property in JSON Pointer notation and the dataset that specific value came from. All features must have a root level source which is the default source if a specific property's source is not specified. |
+| filename				| string	| Name of the file being queried. |
+| theme					| string	| Name of the Overture theme being queried. |
+| type					| string	| Name of the Overture feature type being queried. |
+
+</div>
 </details>
 
 ## Data access and retrieval

--- a/docs/guides/addresses.mdx
+++ b/docs/guides/addresses.mdx
@@ -40,7 +40,7 @@ Address data can be used for a variety of purposes, which can include:
 An `address` is a feature type that represents a physical place through a series of attributes: street number, street name, unit, address_levels, postalcode and/or country. They also have a `Point` geometry, which provides an approximate location of the position most commonly associated with the feature. We encourage you to consult the [schema reference documentation for the `address` feature type](/schema/reference/addresses/address).
 
 <details>
-	<summary>Counts, per country, of the address feature type</summary>
+	<summary>Address counts, per country</summary>
 <div>
 
 | country	| address count |

--- a/docs/guides/base.mdx
+++ b/docs/guides/base.mdx
@@ -26,118 +26,118 @@ The Overture Maps base theme provides the land, water, infrastructure, and bathy
 <Tabs>
 <TabItem value="bathymetry" label="bathymetry" default>
 
-| column					| type		| description |
-| ------------------------- | --------- | ----------- |
-| id                    	| string	| A feature ID that may be associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
-| geometry              	| binary	| A building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). MUST be a Polygon as defined by GeoJSON schema. |
-| bbox                  	| struct	| Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
-| version               	| integer	| Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
-| sources               	| struct	| The array of source information for the properties of a given feature. Each source object lists the property in JSON Pointer notation and the dataset from which that specific value originated. |
-| depth						| integer	| Depth below surface level (in meters) of the feature. |
-| cartography              	| struct	| Defines cartographic hints for optimal use of Overture features in map-making. |
-| filename					| string	| Name of the file being queried. |
-| theme						| string	| Name of the Overture theme being queried. |
-| type						| string	| Name of the Overture feature type being queried. |
+| column | type | description |
+| --- | --- | --- |
+| id | string | A feature ID that may be associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
+| geometry | binary | A building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). MUST be a Polygon as defined by GeoJSON schema. |
+| bbox | struct | Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
+| version | integer | Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
+| sources | struct | The array of source information for the properties of a given feature. Each source object lists the property in JSON Pointer notation and the dataset from which that specific value originated. |
+| depth | integer | Depth below surface level (in meters) of the feature. |
+| cartography | struct | Defines cartographic hints for optimal use of Overture features in map-making. |
+| filename | string | Name of the file being queried. |
+| theme | string | Name of the Overture theme being queried. |
+| type | string | Name of the Overture feature type being queried. |
 
 </TabItem>
 <TabItem value="infrastructure" label="infrastructure" default>
 
-| column					| type		| description |
-| ------------------------- | --------- | ----------- |
-| id                    	| varchar	| A feature ID that may be associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
-| geometry              	| binary	| A building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). MUST be a Polygon as defined by GeoJSON schema. |
-| bbox                  	| struct	| Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
-| version               	| integer	| Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
-| sources               	| struct	| The array of source information for the properties of a given feature. Each source object lists the property in JSON Pointer notation and the dataset from which that specific value originated. |
-| subtype               	| varchar	| A broad category of the building type and purpose. |
-| names                 	| struct	| The name associated with the feature. The first entry in the array of names must have a "local" language. |
-| class                 	| varchar	| Further delineation of the building's built purpose. |
-| level                 	| integer	| The building feature's Z-order, i.e., stacking order. A Z-order of 0 is ground level. |
-| filename					| varchar	| Name of the file being queried. |
-| theme						| varchar	| Name of the Overture theme being queried. |
-| type						| varchar	| Name of the Overture feature type being queried. |
+| column | type | description |
+| --- | --- | --- |
+| id | varchar | A feature ID that may be associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
+| geometry | binary | A building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). MUST be a Polygon as defined by GeoJSON schema. |
+| bbox | struct | Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
+| version | integer | Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
+| sources | struct | The array of source information for the properties of a given feature. Each source object lists the property in JSON Pointer notation and the dataset from which that specific value originated. |
+| subtype | varchar | A broad category of the building type and purpose. |
+| names | struct | The name associated with the feature. The first entry in the array of names must have a "local" language. |
+| class | varchar | Further delineation of the building's built purpose. |
+| level | integer | The building feature's Z-order, i.e., stacking order. A Z-order of 0 is ground level. |
+| filename | varchar | Name of the file being queried. |
+| theme | varchar | Name of the Overture theme being queried. |
+| type | varchar | Name of the Overture feature type being queried. |
 
 </TabItem>
 <TabItem value="land" label="land" default>
 
-| column					| type		| description |
-| ------------------------- | --------- | ----------- |
-| id                    	| string	| A feature ID that may be associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
-| geometry              	| binary	| A building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). MUST be a Polygon as defined by GeoJSON schema. |
-| bbox                  	| struct	| Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
-| version               	| integer	| Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
-| sources               	| struct	| The array of source information for the properties of a given feature. Each source object lists the property in JSON Pointer notation and the dataset from which that specific value originated. |
-| level                 	| integer	| The building feature's Z-order, i.e., stacking order. A Z-order of 0 is ground level. |
-| subtype               	| string	| A broad category of the building type and purpose. |
-| class                 	| string	| Further delineation of the building's built purpose. |
-| surface					| string	| Surface material, mostly from the OSM tag, with some normalization. |
-| names                 	| struct	| The name associated with the feature. The first entry in the array of names must have a "local" language. |
-| source_tags				| struct	| Any attributes/tags from the original source data that should be passed through. |
-| wikidata					| string	| The Wikidata ID for the feature. |
-| elevation					| integer	| Elevation above sea level (in meters) of the feature. |
-| filename					| string	| Name of the file being queried. |
-| theme						| string	| Name of the Overture theme being queried. |
-| type						| string	| Name of the Overture feature type being queried. |
+| column | type | description |
+| --- | --- | --- |
+| id | string | A feature ID that may be associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
+| geometry | binary | A building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). MUST be a Polygon as defined by GeoJSON schema. |
+| bbox | struct | Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
+| version | integer | Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
+| sources | struct | The array of source information for the properties of a given feature. Each source object lists the property in JSON Pointer notation and the dataset from which that specific value originated. |
+| level | integer | The building feature's Z-order, i.e., stacking order. A Z-order of 0 is ground level. |
+| subtype | string | A broad category of the building type and purpose. |
+| class | string | Further delineation of the building's built purpose. |
+| surface | string | Surface material, mostly from the OSM tag, with some normalization. |
+| names | struct | The name associated with the feature. The first entry in the array of names must have a "local" language. |
+| source_tags | struct | Any attributes/tags from the original source data that should be passed through. |
+| wikidata | string | The Wikidata ID for the feature. |
+| elevation | integer | Elevation above sea level (in meters) of the feature. |
+| filename | string | Name of the file being queried. |
+| theme | string | Name of the Overture theme being queried. |
+| type | string | Name of the Overture feature type being queried. |
 
 </TabItem>
 <TabItem value="land_cover" label="land_cover" default>
 
-| column					| type		| description |
-| ------------------------- | --------- | ----------- |
-| id                    	| string	| A feature ID that may be associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
-| geometry              	| binary	| A building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). MUST be a Polygon as defined by GeoJSON schema. |
-| bbox                  	| struct	| Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
-| version               	| integer	| Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
-| sources               	| struct	| The array of source information for the properties of a given feature. Each source object lists the property in JSON Pointer notation and the dataset from which that specific value originated. |
-| cartography              	| struct	| Defines cartographic hints for optimal use of Overture features in map-making. |
-| subtype               	| string	| A broad category of the building type and purpose. |
-| filename					| string	| Name of the file being queried. |
-| theme						| string	| Name of the Overture theme being queried. |
-| type						| string	| Name of the Overture feature type being queried. |
+| column | type | description |
+| --- | --- | --- |
+| id | string | A feature ID that may be associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
+| geometry | binary | A building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). MUST be a Polygon as defined by GeoJSON schema. |
+| bbox | struct | Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
+| version | integer | Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
+| sources | struct | The array of source information for the properties of a given feature. Each source object lists the property in JSON Pointer notation and the dataset from which that specific value originated. |
+| cartography | struct | Defines cartographic hints for optimal use of Overture features in map-making. |
+| subtype | string | A broad category of the building type and purpose. |
+| filename | string | Name of the file being queried. |
+| theme | string | Name of the Overture theme being queried. |
+| type | string | Name of the Overture feature type being queried. |
 
 </TabItem>
 <TabItem value="land_use" label="land_use" default>
 
-| column					| type		| description |
-| ------------------------- | --------- | ----------- |
-| id                    	| string	| A feature ID that may be associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
-| geometry              	| binary	| A building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). MUST be a Polygon as defined by GeoJSON schema. |
-| bbox                  	| struct	| Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
-| version               	| integer	| Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
-| sources               	| struct	| The array of source information for the properties of a given feature. Each source object lists the property in JSON Pointer notation and the dataset from which that specific value originated. |
-| level                 	| integer	| The building feature's Z-order, i.e., stacking order. A Z-order of 0 is ground level. |
-| subtype               	| string	| A broad category of the building type and purpose. |
-| class                 	| string	| Further delineation of the building's built purpose. |
-| surface					| string	| Surface material, mostly from the OSM tag, with some normalization. |
-| names                 	| struct	| The name associated with the feature. The first entry in the array of names must have a "local" language. |
-| source_tags				| struct	| Any attributes/tags from the original source data that should be passed through. |
-| wikidata					| string	| The Wikidata ID for the feature. |
-| elevation					| integer	| Elevation above sea level (in meters) of the feature. |
-| filename					| string	| Name of the file being queried. |
-| theme						| string	| Name of the Overture theme being queried. |
-| type						| string	| Name of the Overture feature type being queried. |
+| column | type | description |
+| --- | --- | --- |
+| id | string | A feature ID that may be associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
+| geometry | binary | A building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). MUST be a Polygon as defined by GeoJSON schema. |
+| bbox | struct | Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
+| version | integer | Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
+| sources | struct | The array of source information for the properties of a given feature. Each source object lists the property in JSON Pointer notation and the dataset from which that specific value originated. |
+| level | integer | The building feature's Z-order, i.e., stacking order. A Z-order of 0 is ground level. |
+| subtype | string | A broad category of the building type and purpose. |
+| class | string | Further delineation of the building's built purpose. |
+| surface | string | Surface material, mostly from the OSM tag, with some normalization. |
+| names | struct | The name associated with the feature. The first entry in the array of names must have a "local" language. |
+| source_tags | struct | Any attributes/tags from the original source data that should be passed through. |
+| wikidata | string | The Wikidata ID for the feature. |
+| elevation | integer | Elevation above sea level (in meters) of the feature. |
+| filename | string | Name of the file being queried. |
+| theme | string | Name of the Overture theme being queried. |
+| type | string | Name of the Overture feature type being queried. |
 
 </TabItem>
 <TabItem value="water" label="water" default>
 
-| column					| type		| description |
-| ------------------------- | --------- | ----------- |
-| id                    	| string	| A feature ID that may be associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
-| geometry              	| binary	| A building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). MUST be a Polygon as defined by GeoJSON schema. |
-| bbox                  	| struct	| Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
-| version               	| integer	| Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
-| sources               	| struct	| The array of source information for the properties of a given feature. Each source object lists the property in JSON Pointer notation and the dataset from which that specific value originated. |
-| level                 	| integer	| The building feature's Z-order, i.e., stacking order. A Z-order of 0 is ground level. |
-| subtype               	| string	| A broad category of the building type and purpose. |
-| class                 	| string	| Further delineation of the building's built purpose. |
-| names                 	| struct	| The name associated with the feature. The first entry in the array of names must have a "local" language. |
-| source_tags				| struct	| Any attributes/tags from the original source data that should be passed through. |
-| wikidata					| string	| The Wikidata ID for the feature. |
-| is_salt					| boolean	| Indicates the presence of salt water. |
-| is_intermittent			| boolean	| Indicates whether or not the water is intermittent. |
-| filename					| string	| Name of the file being queried. |
-| theme						| string	| Name of the Overture theme being queried. |
-| type						| string	| Name of the Overture feature type being queried. |
+| column | type | description |
+| --- | --- | --- |
+| id | string | A feature ID that may be associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
+| geometry | binary | A building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). MUST be a Polygon as defined by GeoJSON schema. |
+| bbox | struct | Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
+| version | integer | Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
+| sources | struct | The array of source information for the properties of a given feature. Each source object lists the property in JSON Pointer notation and the dataset from which that specific value originated. |
+| level | integer | The building feature's Z-order, i.e., stacking order. A Z-order of 0 is ground level. |
+| subtype | string | A broad category of the building type and purpose. |
+| class | string | Further delineation of the building's built purpose. |
+| names | struct | The name associated with the feature. The first entry in the array of names must have a "local" language. |
+| source_tags | struct | Any attributes/tags from the original source data that should be passed through. |
+| wikidata | string | The Wikidata ID for the feature. |
+| is_salt | boolean | Indicates the presence of salt water. |
+| is_intermittent | boolean | Indicates whether or not the water is intermittent. |
+| filename | string | Name of the file being queried. |
+| theme | string | Name of the Overture theme being queried. |
+| type | string | Name of the Overture feature type being queried. |
 
 </TabItem>
 </Tabs>
@@ -150,38 +150,38 @@ Overture's base theme data is freely available on both Amazon S3 and Microsoft A
 
 <Tabs>
   <TabItem value="bathymetry" label="Bathymetry">
-    | Provider | Location |
-    | -------- | -------- |
+    | provider | location |
+    | --- | --- |
     | Amazon S3 | <QueryBuilder query="s3://overturemaps-us-west-2/release/__OVERTURE_RELEASE/theme=base/type=bathymetry/*" language="text"></QueryBuilder> |
     | Azure Blob Storage | <QueryBuilder query="https://overturemapswestus2.blob.core.windows.net/release/__OVERTURE_RELEASE/theme=base/type=bathymetry/*" language="text"></QueryBuilder> |
   </TabItem>
   <TabItem value="infrastructure" label="Infrastructure">
-    | Provider | Location |
-    | -------- | -------- |
+    | provider | location |
+    | --- | --- |
     | Amazon S3 | <QueryBuilder query="s3://overturemaps-us-west-2/release/__OVERTURE_RELEASE/theme=base/type=infrastructure/*" language="text"></QueryBuilder> |
     | Azure Blob Storage | <QueryBuilder query="https://overturemapswestus2.blob.core.windows.net/release/__OVERTURE_RELEASE/theme=base/type=infrastructure/*" language="text"></QueryBuilder> |
   </TabItem>
   <TabItem value="land" label="Land">
-    | Provider | Location |
-    | -------- | -------- |
+    | provider | location |
+    | --- | --- |
     | Amazon S3 | <QueryBuilder query="s3://overturemaps-us-west-2/release/__OVERTURE_RELEASE/theme=base/type=land/*" language="text"></QueryBuilder> |
     | Azure Blob Storage | <QueryBuilder query="https://overturemapswestus2.blob.core.windows.net/release/__OVERTURE_RELEASE/theme=base/type=land/*" language="text"></QueryBuilder> |
   </TabItem>
   <TabItem value="land_cover" label="Land Cover">
-    | Provider | Location |
-    | -------- | -------- |
+    | provider | location |
+    | --- | --- |
     | Amazon S3 | <QueryBuilder query="s3://overturemaps-us-west-2/release/__OVERTURE_RELEASE/theme=base/type=land_cover/*" language="text"></QueryBuilder> |
     | Azure Blob Storage | <QueryBuilder query="https://overturemapswestus2.blob.core.windows.net/release/__OVERTURE_RELEASE/theme=base/type=land_cover/*" language="text"></QueryBuilder> |
   </TabItem>
   <TabItem value="land_use" label="Land Use">
-    | Provider | Location |
-    | -------- | -------- |
+    | provider | location |
+    | --- | --- |
     | Amazon S3 | <QueryBuilder query="s3://overturemaps-us-west-2/release/__OVERTURE_RELEASE/theme=base/type=land_use/*" language="text"></QueryBuilder> |
     | Azure Blob Storage | <QueryBuilder query="https://overturemapswestus2.blob.core.windows.net/release/__OVERTURE_RELEASE/theme=base/type=land_use/*" language="text"></QueryBuilder> |
   </TabItem>
   <TabItem value="water" label="Water">
-    | Provider | Location |
-    | -------- | -------- |
+    | provider | location |
+    | --- | --- |
     | Amazon S3 | <QueryBuilder query="s3://overturemaps-us-west-2/release/__OVERTURE_RELEASE/theme=base/type=water/*" language="text"></QueryBuilder> |
     | Azure Blob Storage | <QueryBuilder query="https://overturemapswestus2.blob.core.windows.net/release/__OVERTURE_RELEASE/theme=base/type=water/*" language="text"></QueryBuilder> |
   </TabItem>

--- a/docs/guides/base.mdx
+++ b/docs/guides/base.mdx
@@ -40,6 +40,24 @@ The Overture Maps base theme provides the land, water, infrastructure, and bathy
 | type						| string	| Name of the Overture feature type being queried. |
 
 </TabItem>
+<TabItem value="infrastructure" label="infrastructure" default>
+
+| column					| type		| description |
+| ------------------------- | --------- | ----------- |
+| id                    	| varchar	| A feature ID that may be associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
+| geometry              	| binary	| A building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). MUST be a Polygon as defined by GeoJSON schema. |
+| bbox                  	| struct	| Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
+| version               	| integer	| Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
+| sources               	| struct	| The array of source information for the properties of a given feature. Each source object lists the property in JSON Pointer notation and the dataset from which that specific value originated. |
+| subtype               	| varchar	| A broad category of the building type and purpose. |
+| names                 	| struct	| The name associated with the feature. The first entry in the array of names must have a "local" language. |
+| class                 	| varchar	| Further delineation of the building's built purpose. |
+| level                 	| integer	| The building feature's Z-order, i.e., stacking order. A Z-order of 0 is ground level. |
+| filename					| varchar	| Name of the file being queried. |
+| theme						| varchar	| Name of the Overture theme being queried. |
+| type						| varchar	| Name of the Overture feature type being queried. |
+
+</TabItem>
 <TabItem value="land" label="land" default>
 
 | column					| type		| description |
@@ -120,24 +138,6 @@ The Overture Maps base theme provides the land, water, infrastructure, and bathy
 | filename					| string	| Name of the file being queried. |
 | theme						| string	| Name of the Overture theme being queried. |
 | type						| string	| Name of the Overture feature type being queried. |
-
-</TabItem>
-<TabItem value="infrastructure" label="infrastructure" default>
-
-| column					| type		| description |
-| ------------------------- | --------- | ----------- |
-| id                    	| varchar	| A feature ID that may be associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
-| geometry              	| binary	| A building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). MUST be a Polygon as defined by GeoJSON schema. |
-| bbox                  	| struct	| Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
-| version               	| integer	| Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
-| sources               	| struct	| The array of source information for the properties of a given feature. Each source object lists the property in JSON Pointer notation and the dataset from which that specific value originated. |
-| subtype               	| varchar	| A broad category of the building type and purpose. |
-| names                 	| struct	| The name associated with the feature. The first entry in the array of names must have a "local" language. |
-| class                 	| varchar	| Further delineation of the building's built purpose. |
-| level                 	| integer	| The building feature's Z-order, i.e., stacking order. A Z-order of 0 is ground level. |
-| filename					| varchar	| Name of the file being queried. |
-| theme						| varchar	| Name of the Overture theme being queried. |
-| type						| varchar	| Name of the Overture feature type being queried. |
 
 </TabItem>
 </Tabs>

--- a/docs/guides/base.mdx
+++ b/docs/guides/base.mdx
@@ -18,6 +18,132 @@ The Overture Maps base theme provides the land, water, infrastructure, and bathy
 - **`land_use`**: classifications of the human use of a section of land; translates landuse tag from OpenStreetMap.
 - **`water`**: physical representations of inland and ocean marine surfaces; translates natural and waterway tags from OpenStreetMap.
 
+## Understanding the parquet files
+
+<details>
+	<summary>Schema for the GeoParquet files in the base theme</summary>
+<div>
+<Tabs>
+<TabItem value="bathymetry" label="bathymetry" default>
+
+| column					| type		| description |
+| ------------------------- | --------- | ----------- |
+| id                    	| string	| A feature ID that may be associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
+| geometry              	| binary	| A building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). MUST be a Polygon as defined by GeoJSON schema. |
+| bbox                  	| struct	| Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
+| version               	| integer	| Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
+| sources               	| struct	| The array of source information for the properties of a given feature. Each source object lists the property in JSON Pointer notation and the dataset from which that specific value originated. |
+| depth						| integer	| Depth below surface level (in meters) of the feature. |
+| cartography              	| struct	| Defines cartographic hints for optimal use of Overture features in map-making. |
+| filename					| string	| Name of the file being queried. |
+| theme						| string	| Name of the Overture theme being queried. |
+| type						| string	| Name of the Overture feature type being queried. |
+
+</TabItem>
+<TabItem value="land" label="land" default>
+
+| column					| type		| description |
+| ------------------------- | --------- | ----------- |
+| id                    	| string	| A feature ID that may be associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
+| geometry              	| binary	| A building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). MUST be a Polygon as defined by GeoJSON schema. |
+| bbox                  	| struct	| Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
+| version               	| integer	| Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
+| sources               	| struct	| The array of source information for the properties of a given feature. Each source object lists the property in JSON Pointer notation and the dataset from which that specific value originated. |
+| level                 	| integer	| The building feature's Z-order, i.e., stacking order. A Z-order of 0 is ground level. |
+| subtype               	| string	| A broad category of the building type and purpose. |
+| class                 	| string	| Further delineation of the building's built purpose. |
+| surface					| string	| Surface material, mostly from the OSM tag, with some normalization. |
+| names                 	| struct	| The name associated with the feature. The first entry in the array of names must have a "local" language. |
+| source_tags				| struct	| Any attributes/tags from the original source data that should be passed through. |
+| wikidata					| string	| The Wikidata ID for the feature. |
+| elevation					| integer	| Elevation above sea level (in meters) of the feature. |
+| filename					| string	| Name of the file being queried. |
+| theme						| string	| Name of the Overture theme being queried. |
+| type						| string	| Name of the Overture feature type being queried. |
+
+</TabItem>
+<TabItem value="land_cover" label="land_cover" default>
+
+| column					| type		| description |
+| ------------------------- | --------- | ----------- |
+| id                    	| string	| A feature ID that may be associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
+| geometry              	| binary	| A building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). MUST be a Polygon as defined by GeoJSON schema. |
+| bbox                  	| struct	| Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
+| version               	| integer	| Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
+| sources               	| struct	| The array of source information for the properties of a given feature. Each source object lists the property in JSON Pointer notation and the dataset from which that specific value originated. |
+| cartography              	| struct	| Defines cartographic hints for optimal use of Overture features in map-making. |
+| subtype               	| string	| A broad category of the building type and purpose. |
+| filename					| string	| Name of the file being queried. |
+| theme						| string	| Name of the Overture theme being queried. |
+| type						| string	| Name of the Overture feature type being queried. |
+
+</TabItem>
+<TabItem value="land_use" label="land_use" default>
+
+| column					| type		| description |
+| ------------------------- | --------- | ----------- |
+| id                    	| string	| A feature ID that may be associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
+| geometry              	| binary	| A building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). MUST be a Polygon as defined by GeoJSON schema. |
+| bbox                  	| struct	| Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
+| version               	| integer	| Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
+| sources               	| struct	| The array of source information for the properties of a given feature. Each source object lists the property in JSON Pointer notation and the dataset from which that specific value originated. |
+| level                 	| integer	| The building feature's Z-order, i.e., stacking order. A Z-order of 0 is ground level. |
+| subtype               	| string	| A broad category of the building type and purpose. |
+| class                 	| string	| Further delineation of the building's built purpose. |
+| surface					| string	| Surface material, mostly from the OSM tag, with some normalization. |
+| names                 	| struct	| The name associated with the feature. The first entry in the array of names must have a "local" language. |
+| source_tags				| struct	| Any attributes/tags from the original source data that should be passed through. |
+| wikidata					| string	| The Wikidata ID for the feature. |
+| elevation					| integer	| Elevation above sea level (in meters) of the feature. |
+| filename					| string	| Name of the file being queried. |
+| theme						| string	| Name of the Overture theme being queried. |
+| type						| string	| Name of the Overture feature type being queried. |
+
+</TabItem>
+<TabItem value="water" label="water" default>
+
+| column					| type		| description |
+| ------------------------- | --------- | ----------- |
+| id                    	| string	| A feature ID that may be associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
+| geometry              	| binary	| A building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). MUST be a Polygon as defined by GeoJSON schema. |
+| bbox                  	| struct	| Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
+| version               	| integer	| Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
+| sources               	| struct	| The array of source information for the properties of a given feature. Each source object lists the property in JSON Pointer notation and the dataset from which that specific value originated. |
+| level                 	| integer	| The building feature's Z-order, i.e., stacking order. A Z-order of 0 is ground level. |
+| subtype               	| string	| A broad category of the building type and purpose. |
+| class                 	| string	| Further delineation of the building's built purpose. |
+| names                 	| struct	| The name associated with the feature. The first entry in the array of names must have a "local" language. |
+| source_tags				| struct	| Any attributes/tags from the original source data that should be passed through. |
+| wikidata					| string	| The Wikidata ID for the feature. |
+| is_salt					| boolean	| Indicates the presence of salt water. |
+| is_intermittent			| boolean	| Indicates whether or not the water is intermittent. |
+| filename					| string	| Name of the file being queried. |
+| theme						| string	| Name of the Overture theme being queried. |
+| type						| string	| Name of the Overture feature type being queried. |
+
+</TabItem>
+<TabItem value="infrastructure" label="infrastructure" default>
+
+| column					| type		| description |
+| ------------------------- | --------- | ----------- |
+| id                    	| varchar	| A feature ID that may be associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
+| geometry              	| binary	| A building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). MUST be a Polygon as defined by GeoJSON schema. |
+| bbox                  	| struct	| Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
+| version               	| integer	| Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
+| sources               	| struct	| The array of source information for the properties of a given feature. Each source object lists the property in JSON Pointer notation and the dataset from which that specific value originated. |
+| subtype               	| varchar	| A broad category of the building type and purpose. |
+| names                 	| struct	| The name associated with the feature. The first entry in the array of names must have a "local" language. |
+| class                 	| varchar	| Further delineation of the building's built purpose. |
+| level                 	| integer	| The building feature's Z-order, i.e., stacking order. A Z-order of 0 is ground level. |
+| filename					| varchar	| Name of the file being queried. |
+| theme						| varchar	| Name of the Overture theme being queried. |
+| type						| varchar	| Name of the Overture feature type being queried. |
+
+</TabItem>
+</Tabs>
+</div>
+</details>
+
 ## Data access and retrieval
 
 Overture's base theme data is freely available on both Amazon S3 and Microsoft Azure Blob Storage at these locations:

--- a/docs/guides/base.mdx
+++ b/docs/guides/base.mdx
@@ -53,6 +53,10 @@ The Overture Maps base theme provides the land, water, infrastructure, and bathy
 | names | struct | The name associated with the feature. The first entry in the array of names must have a "local" language. |
 | class | varchar | Further delineation of the building's built purpose. |
 | level | integer | The building feature's Z-order, i.e., stacking order. A Z-order of 0 is ground level. |
+| height | double | Height of the feature in meters. |
+| surface | varchar | Surface material, mostly from the OSM tag, with some normalization. |
+| source_tags | struct | Any attributes/tags from the original source data that should be passed through. |
+| wikidata | varchar | The Wikidata ID for the feature. |
 | filename | varchar | Name of the file being queried. |
 | theme | varchar | Name of the Overture theme being queried. |
 | type | varchar | Name of the Overture feature type being queried. |

--- a/docs/guides/buildings.mdx
+++ b/docs/guides/buildings.mdx
@@ -2,6 +2,7 @@
 title: Buildings
 description: Over 2.6B buildings globally
 ---
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import QueryBuilder from '@site/src/components/queryBuilder';
@@ -71,76 +72,85 @@ Above is a visualization of San Diego, USA where multiple datasets are conflated
 
 Currently, the Overture buildings dataset is a combination of the following open building datasets:
 
-| Source                     |  Type                 | Conflation <br /> Priority | Count    |
-| -------------------------- | --------------------- | -------------------------- | ----------- |
-| [OpenStreetMap](//osm.org) | Community-contributed | 1 | ~635 Million |
-| [Esri Community Maps](https://communitymaps.arcgis.com/home) | Community-contributed | 2| ~11 Million |
-| [Instituto Geográfico Nacional (España)](https://www.ign.es/) | National dataset | 3 | ~11.7 Million |
-| [City of Vancouver, Canada](https://opendata.vancouver.ca/) | Municipal dataset | 4 | ~14 Thousand |
-| [Google Open Buildings](https://sites.research.google/open-buildings/)| ML-derived roofprints<br />  (&gt;90% precision) | 5 | ~350 Million |
-| [Microsoft](https://github.com/microsoft/GlobalMLBuildingFootprints) |ML-derived roofprints  | 6 | ~723 Million |
-| [Google Open Buildings](https://sites.research.google/open-buildings/)| ML-derived roofprints<br />  (&lt;90% precision) | 7 |~650 Million |
-| [Buildings in East Asian Countries](https://zenodo.org/records/8174931)| ML-derived roofprints<br />  | 8 |~213 Million |
+| source																	| type										| conflation priority	| count |
+| ------------------------------------------------------------------------- | ----------------------------------------- | --------------------- | ----- |
+| [OpenStreetMap](//osm.org)												| Community-contributed						| 1						| ~635 Million |
+| [Esri Community Maps](https://communitymaps.arcgis.com/home)				| Community-contributed						| 2						| ~11 Million |
+| [Instituto Geográfico Nacional (España)](https://www.ign.es/)				| National dataset							| 3						| ~11.7 Million |
+| [City of Vancouver, Canada](https://opendata.vancouver.ca/)				| Municipal dataset							| 4						| ~14 Thousand |
+| [Google Open Buildings](https://sites.research.google/open-buildings/)	| ML-derived roofprints (~90% precision)	| 5						| ~350 Million |
+| [Microsoft](https://github.com/microsoft/GlobalMLBuildingFootprints)		| ML-derived roofprints						| 6						| ~723 Million |
+| [Google Open Buildings](https://sites.research.google/open-buildings/)	| ML-derived roofprints (~90% precision)	| 7						| ~650 Million |
+| [Buildings in East Asian Countries](https://zenodo.org/records/8174931)	| ML-derived roofprints						| 8						| ~213 Million |
 
-## Understanding the Parquet Files
+## Understanding the parquet files
 
 <details>
-        <summary>Schema for the GeoParquet files in the buildings theme</summary>
-        <div>
+	<summary>Schema for the GeoParquet files in the buildings theme</summary>
+<div>
 <Tabs>
 <TabItem value="building" label="building" default>
 
-| column                 | type    | description |
-| ---------------------- | ------- | ------------ |
-| id                     | varchar | A feature ID that may be associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
-| geometry               | blob    | A building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). MUST be a Polygon as defined by GeoJSON schema. |
-| bbox                   | struct  | Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
-| version                | integer | Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed.
-| sources                | struct  | The array of source information for the properties of a given feature. Each source object lists the property in JSON Pointer notation and the dataset from which that specific value originated. |
-| subtype                | varchar | A broad category of the building type and purpose. |
-| names                  | struct  | The name associated with the feature. The first entry in the array of names must have a "local" language. |
-| class                  | varchar | Further delineation of the building's built purpose. |
-| level                  | integer | The building feature's Z-order, i.e., stacking order. A Z-order of 0 is ground level. |
-| has_parts              | boolean | Flag indicating whether the building has parts. |
-| is_underground         | boolean | Whether the entire building or part is completely below ground. This is useful for rendering which typically omits these buildings or styles them differently because they are not visible above ground. This is different than the level column which is used to indicate z-ordering of elements and negative values may be above ground. |
-| height                 | double  | Height of the building or part in meters. The height is the distance from the lowest point to the highest point. |
-| num_floors             | integer | Number of above-ground floors of the building or part. |
-| num_floors_underground | integer | Number of below-ground floors of the building or part.
-| min_height             | double  | The height of the bottom part of building in meters. Used if a building or part of building starts above the ground level. |
-| min_floor              | integer | The "start" floor of a building or building part. Indicates that the building or part is "floating" and its bottom-most floor is above ground level, usually because it is part of a larger building in which some parts do reach ground level. |
-| facade_color           | varchar | The color (name or color triplet) of the facade of a building or building part in hexadecimal. |
-| facade_material        | varchar | The outer surface material of building facade. |
-| roof_material          | varchar | The outermost material of the roof. |
-| roof_shape             | varchar | The shape of the roof. |
-| roof_direction         | double  | Bearing of the roof ridge line. |
-| roof_orientation       | varchar | Orientation of the roof shape relative to the footprint shape. Either "along" or "across." |
-| roof_color             | varchar | The color (name or color triplet) of the roof of a building or building part in hexadecimal. |
+| column					| type		| description |
+| ------------------------- | --------- | ----------- |
+| id                    	| string	| A feature ID that may be associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
+| geometry              	| binary	| A building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). MUST be a Polygon as defined by GeoJSON schema. |
+| bbox                  	| struct	| Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
+| version               	| integer	| Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
+| sources               	| struct	| The array of source information for the properties of a given feature. Each source object lists the property in JSON Pointer notation and the dataset from which that specific value originated. |
+| subtype               	| string	| A broad category of the building type and purpose. |
+| names                 	| struct	| The name associated with the feature. The first entry in the array of names must have a "local" language. |
+| class                 	| string	| Further delineation of the building's built purpose. |
+| level                 	| integer	| The building feature's Z-order, i.e., stacking order. A Z-order of 0 is ground level. |
+| has_parts             	| boolean	| Flag indicating whether the building has parts. |
+| is_underground        	| boolean	| Whether the entire building or part is completely below ground. This is useful for rendering which typically omits these buildings or styles them differently because they are not visible above ground. This is different than the level column which is used to indicate z-ordering of elements and negative values may be above ground. |
+| height                	| double	| Height of the building or part in meters. The height is the distance from the lowest point to the highest point. |
+| num_floors            	| integer	| Number of above-ground floors of the building or part. |
+| num_floors_underground	| integer	| Number of below-ground floors of the building or part. |
+| min_height            	| double	| The height of the bottom part of building in meters. Used if a building or part of building starts above the ground level. |
+| min_floor             	| integer	| The "start" floor of a building or building part. Indicates that the building or part is "floating" and its bottom-most floor is above ground level, usually because it is part of a larger building in which some parts do reach ground level. |
+| facade_color          	| string	| The color (name or color triplet) of the facade of a building or building part in hexadecimal. |
+| facade_material       	| string	| The outer surface material of building facade. |
+| roof_material         	| string	| The outermost material of the roof. |
+| roof_shape            	| string	| The shape of the roof. |
+| roof_direction        	| double	| Bearing of the roof ridge line. |
+| roof_orientation     		| string	| Orientation of the roof shape relative to the footprint shape. Either "along" or "across." |
+| roof_color             	| string	| The color (name or color triplet) of the roof of a building or building part in hexadecimal. |
+| roof_height           	| double	| The height of the building roof in meters. This represents the distance from the base of the roof to the highest point of the roof. |
+| filename					| string	| Name of the file being queried. |
+| theme						| varchar	| Name of the Overture theme being queried. |
+| type						| varchar	| Name of the Overture feature type being queried. |
 
 </TabItem>
 <TabItem value="building_part" label="building_part" default>
-| column                 | type    | description |
-| ---------------------- | ------- | ------------ |
-| id                     | varchar | A feature ID that may be associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
-| geometry               | blob    | A building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). MUST be a Polygon as defined by GeoJSON schema. |
-| bbox                   | struct  | Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
-| version                | integer | Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed.
-| sources                | struct  | The array of source information for the properties of a given feature. Each source object lists the property in JSON Pointer notation and the dataset from which that specific value originated. |
-| names                  | struct  | The name associated with the feature. The first entry in the array of names must have a "local" language. |
-| level                  | integer | The building feature's Z-order, i.e., stacking order. A Z-order of 0 is ground level. |
-| is_underground         | boolean | Whether the entire building or part is completely below ground. This is useful for rendering which typically omits these buildings or styles them differently because they are not visible above ground. This is different than the level column which is used to indicate z-ordering of elements and negative values may be above ground. |
-| height                 | double  | Height of the building or part in meters. The height is the distance from the lowest point to the highest point. |
-| num_floors             | integer | Number of above-ground floors of the building or part. |
-| num_floors_underground | integer | Number of below-ground floors of the building or part. |
-| min_height             | double  | The height of the bottom part of building in meters. Used if a building or part of building starts above the ground level. |
-| min_floor              | integer | The "start" floor of a building or building part. Indicates that the building or part is "floating" and its bottom-most floor is above ground level, usually because it is part of a larger building in which some parts do reach ground level. |
-| facade_color           | varchar | The color (name or color triplet) of the facade of a building or building part in hexadecimal. |
-| facade_material        | varchar | The outer surface material of building facade. |
-| roof_material          | varchar | The outermost material of the roof. |
-| roof_shape             | varchar | The shape of the roof. |
-| roof_direction         | double  | Bearing of the roof ridge line. |
-| roof_orientation       | varchar | Orientation of the roof shape relative to the footprint shape. Either "along" or "across." |
-| roof_color             | varchar | The color (name or color triplet) of the roof of a building or building part in hexadecimal. |
-| building_id            | varchar | The building ID to which this part belongs.|
+
+| column                 	| type    	| description |
+| ------------------------- | --------- | ----------- |
+| id                    	| string	| A feature ID that may be associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
+| geometry              	| binary	| A building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). MUST be a Polygon as defined by GeoJSON schema. |
+| bbox                  	| struct	| Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
+| version               	| integer	| Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
+| sources               	| struct	| The array of source information for the properties of a given feature. Each source object lists the property in JSON Pointer notation and the dataset from which that specific value originated. |
+| names                 	| struct	| The name associated with the feature. The first entry in the array of names must have a "local" language. |
+| level                 	| integer	| The building feature's Z-order, i.e., stacking order. A Z-order of 0 is ground level. |
+| is_underground        	| boolean	| Whether the entire building or part is completely below ground. This is useful for rendering which typically omits these buildings or styles them differently because they are not visible above ground. This is different than the level column which is used to indicate z-ordering of elements and negative values may be above ground. |
+| height                	| double	| Height of the building or part in meters. The height is the distance from the lowest point to the highest point. |
+| num_floors            	| integer	| Number of above-ground floors of the building or part. |
+| num_floors_underground	| integer	| Number of below-ground floors of the building or part. |
+| min_height            	| double	| The height of the bottom part of building in meters. Used if a building or part of building starts above the ground level. |
+| min_floor             	| integer	| The "start" floor of a building or building part. Indicates that the building or part is "floating" and its bottom-most floor is above ground level, usually because it is part of a larger building in which some parts do reach ground level. |
+| facade_color          	| string	| The color (name or color triplet) of the facade of a building or building part in hexadecimal. |
+| facade_material       	| string	| The outer surface material of building facade. |
+| roof_material         	| string	| The outermost material of the roof. |
+| roof_shape            	| string	| The shape of the roof. |
+| roof_direction        	| double	| Bearing of the roof ridge line. |
+| roof_orientation      	| string	| Orientation of the roof shape relative to the footprint shape. Either "along" or "across." |
+| roof_color            	| string	| The color (name or color triplet) of the roof of a building or building part in hexadecimal. |
+| roof_height           	| double	| The height of the building roof in meters. This represents the distance from the base of the roof to the highest point of the roof. |
+| building_id           	| string	| The building ID to which this part belongs. |
+| filename					| string	| Name of the file being queried. |
+| theme						| string	| Name of the Overture theme being queried. |
+| type						| string	| Name of the Overture feature type being queried. |
 
 </TabItem>
 </Tabs>

--- a/docs/guides/buildings.mdx
+++ b/docs/guides/buildings.mdx
@@ -78,9 +78,9 @@ Currently, the Overture buildings dataset is a combination of the following open
 | [Esri Community Maps](https://communitymaps.arcgis.com/home) | Community-contributed | 2 | ~11 Million |
 | [Instituto Geográfico Nacional (España)](https://www.ign.es/) | National dataset | 3 | ~11.7 Million |
 | [City of Vancouver, Canada](https://opendata.vancouver.ca/) | Municipal dataset | 4 | ~14 Thousand |
-| [Google Open Buildings](https://sites.research.google/open-buildings/) | ML-derived roofprints (~90% precision) | 5 | ~350 Million |
+| [Google Open Buildings](https://sites.research.google/open-buildings/) | ML-derived roofprints (>90% precision) | 5 | ~350 Million |
 | [Microsoft](https://github.com/microsoft/GlobalMLBuildingFootprints) | ML-derived roofprints | 6 | ~723 Million |
-| [Google Open Buildings](https://sites.research.google/open-buildings/) | ML-derived roofprints (~90% precision) | 7 | ~650 Million |
+| [Google Open Buildings](https://sites.research.google/open-buildings/) | ML-derived roofprints (>90% precision) | 7 | ~650 Million |
 | [Buildings in East Asian Countries](https://zenodo.org/records/8174931) | ML-derived roofprints | 8 | ~213 Million |
 
 ## Understanding the parquet files

--- a/docs/guides/buildings.mdx
+++ b/docs/guides/buildings.mdx
@@ -24,14 +24,14 @@ Overture's building theme data is freely available on both Amazon S3 and Microso
 
 <Tabs>
   <TabItem value="building" label="building" default>
-    | Provider | Location |
-    | -------- | -------- |
+    | provider | location |
+    | --- | --- |
     | Amazon S3 | <QueryBuilder query="s3://overturemaps-us-west-2/release/__OVERTURE_RELEASE/theme=buildings/type=building/*" language="text"></QueryBuilder> |
     | Azure Blob Storage | <QueryBuilder query="https://overturemapswestus2.blob.core.windows.net/release/__OVERTURE_RELEASE/theme=buildings/type=building/*" language="text"></QueryBuilder> |
   </TabItem>
   <TabItem value="building_part" label="building_part">
-    | Provider | Location |
-    | -------- | -------- |
+    | provider | location |
+    | --- | --- |
     | Amazon S3 | <QueryBuilder query="s3://overturemaps-us-west-2/release/__OVERTURE_RELEASE/theme=buildings/type=building_part/*" language="text"></QueryBuilder> |
     | Azure Blob Storage | <QueryBuilder query="https://overturemapswestus2.blob.core.windows.net/release/__OVERTURE_RELEASE/theme=buildings/type=building_part/*" language="text"></QueryBuilder> |
   </TabItem>
@@ -72,16 +72,16 @@ Above is a visualization of San Diego, USA where multiple datasets are conflated
 
 Currently, the Overture buildings dataset is a combination of the following open building datasets:
 
-| source																	| type										| conflation priority	| count |
-| ------------------------------------------------------------------------- | ----------------------------------------- | --------------------- | ----- |
-| [OpenStreetMap](//osm.org)												| Community-contributed						| 1						| ~635 Million |
-| [Esri Community Maps](https://communitymaps.arcgis.com/home)				| Community-contributed						| 2						| ~11 Million |
-| [Instituto Geográfico Nacional (España)](https://www.ign.es/)				| National dataset							| 3						| ~11.7 Million |
-| [City of Vancouver, Canada](https://opendata.vancouver.ca/)				| Municipal dataset							| 4						| ~14 Thousand |
-| [Google Open Buildings](https://sites.research.google/open-buildings/)	| ML-derived roofprints (~90% precision)	| 5						| ~350 Million |
-| [Microsoft](https://github.com/microsoft/GlobalMLBuildingFootprints)		| ML-derived roofprints						| 6						| ~723 Million |
-| [Google Open Buildings](https://sites.research.google/open-buildings/)	| ML-derived roofprints (~90% precision)	| 7						| ~650 Million |
-| [Buildings in East Asian Countries](https://zenodo.org/records/8174931)	| ML-derived roofprints						| 8						| ~213 Million |
+| source | type | conflation priority | count |
+| --- | --- | --- | --- |
+| [OpenStreetMap](//osm.org) | Community-contributed | 1 | ~635 Million |
+| [Esri Community Maps](https://communitymaps.arcgis.com/home) | Community-contributed | 2 | ~11 Million |
+| [Instituto Geográfico Nacional (España)](https://www.ign.es/) | National dataset | 3 | ~11.7 Million |
+| [City of Vancouver, Canada](https://opendata.vancouver.ca/) | Municipal dataset | 4 | ~14 Thousand |
+| [Google Open Buildings](https://sites.research.google/open-buildings/) | ML-derived roofprints (~90% precision) | 5 | ~350 Million |
+| [Microsoft](https://github.com/microsoft/GlobalMLBuildingFootprints) | ML-derived roofprints | 6 | ~723 Million |
+| [Google Open Buildings](https://sites.research.google/open-buildings/) | ML-derived roofprints (~90% precision) | 7 | ~650 Million |
+| [Buildings in East Asian Countries](https://zenodo.org/records/8174931) | ML-derived roofprints | 8 | ~213 Million |
 
 ## Understanding the parquet files
 
@@ -91,66 +91,66 @@ Currently, the Overture buildings dataset is a combination of the following open
 <Tabs>
 <TabItem value="building" label="building" default>
 
-| column					| type		| description |
-| ------------------------- | --------- | ----------- |
-| id                    	| string	| A feature ID that may be associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
-| geometry              	| binary	| A building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). MUST be a Polygon as defined by GeoJSON schema. |
-| bbox                  	| struct	| Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
-| version               	| integer	| Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
-| sources               	| struct	| The array of source information for the properties of a given feature. Each source object lists the property in JSON Pointer notation and the dataset from which that specific value originated. |
-| subtype               	| string	| A broad category of the building type and purpose. |
-| names                 	| struct	| The name associated with the feature. The first entry in the array of names must have a "local" language. |
-| class                 	| string	| Further delineation of the building's built purpose. |
-| level                 	| integer	| The building feature's Z-order, i.e., stacking order. A Z-order of 0 is ground level. |
-| has_parts             	| boolean	| Flag indicating whether the building has parts. |
-| is_underground        	| boolean	| Whether the entire building or part is completely below ground. This is useful for rendering which typically omits these buildings or styles them differently because they are not visible above ground. This is different than the level column which is used to indicate z-ordering of elements and negative values may be above ground. |
-| height                	| double	| Height of the building or part in meters. The height is the distance from the lowest point to the highest point. |
-| num_floors            	| integer	| Number of above-ground floors of the building or part. |
-| num_floors_underground	| integer	| Number of below-ground floors of the building or part. |
-| min_height            	| double	| The height of the bottom part of building in meters. Used if a building or part of building starts above the ground level. |
-| min_floor             	| integer	| The "start" floor of a building or building part. Indicates that the building or part is "floating" and its bottom-most floor is above ground level, usually because it is part of a larger building in which some parts do reach ground level. |
-| facade_color          	| string	| The color (name or color triplet) of the facade of a building or building part in hexadecimal. |
-| facade_material       	| string	| The outer surface material of building facade. |
-| roof_material         	| string	| The outermost material of the roof. |
-| roof_shape            	| string	| The shape of the roof. |
-| roof_direction        	| double	| Bearing of the roof ridge line. |
-| roof_orientation     		| string	| Orientation of the roof shape relative to the footprint shape. Either "along" or "across." |
-| roof_color             	| string	| The color (name or color triplet) of the roof of a building or building part in hexadecimal. |
-| roof_height           	| double	| The height of the building roof in meters. This represents the distance from the base of the roof to the highest point of the roof. |
-| filename					| string	| Name of the file being queried. |
-| theme						| varchar	| Name of the Overture theme being queried. |
-| type						| varchar	| Name of the Overture feature type being queried. |
+| column | type | description |
+| --- | --- | --- |
+| id | string | A feature ID that may be associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
+| geometry | binary | A building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). MUST be a Polygon as defined by GeoJSON schema. |
+| bbox | struct | Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
+| version | integer | Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
+| sources | struct | The array of source information for the properties of a given feature. Each source object lists the property in JSON Pointer notation and the dataset from which that specific value originated. |
+| subtype | string | A broad category of the building type and purpose. |
+| names | struct | The name associated with the feature. The first entry in the array of names must have a "local" language. |
+| class | string | Further delineation of the building's built purpose. |
+| level | integer | The building feature's Z-order, i.e., stacking order. A Z-order of 0 is ground level. |
+| has_parts | boolean | Flag indicating whether the building has parts. |
+| is_underground | boolean | Whether the entire building or part is completely below ground. This is useful for rendering which typically omits these buildings or styles them differently because they are not visible above ground. This is different than the level column which is used to indicate z-ordering of elements and negative values may be above ground. |
+| height | double | Height of the building or part in meters. The height is the distance from the lowest point to the highest point. |
+| num_floors | integer | Number of above-ground floors of the building or part. |
+| num_floors_underground | integer | Number of below-ground floors of the building or part. |
+| min_height | double | The height of the bottom part of building in meters. Used if a building or part of building starts above the ground level. |
+| min_floor | integer | The "start" floor of a building or building part. Indicates that the building or part is "floating" and its bottom-most floor is above ground level, usually because it is part of a larger building in which some parts do reach ground level. |
+| facade_color | string | The color (name or color triplet) of the facade of a building or building part in hexadecimal. |
+| facade_material | string | The outer surface material of building facade. |
+| roof_material | string | The outermost material of the roof. |
+| roof_shape | string | The shape of the roof. |
+| roof_direction | double | Bearing of the roof ridge line. |
+| roof_orientation | string | Orientation of the roof shape relative to the footprint shape. Either "along" or "across." |
+| roof_color | string | The color (name or color triplet) of the roof of a building or building part in hexadecimal. |
+| roof_height | double | The height of the building roof in meters. This represents the distance from the base of the roof to the highest point of the roof. |
+| filename | string | Name of the file being queried. |
+| theme | varchar | Name of the Overture theme being queried. |
+| type | varchar | Name of the Overture feature type being queried. |
 
 </TabItem>
 <TabItem value="building_part" label="building_part" default>
 
-| column                 	| type    	| description |
-| ------------------------- | --------- | ----------- |
-| id                    	| string	| A feature ID that may be associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
-| geometry              	| binary	| A building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). MUST be a Polygon as defined by GeoJSON schema. |
-| bbox                  	| struct	| Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
-| version               	| integer	| Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
-| sources               	| struct	| The array of source information for the properties of a given feature. Each source object lists the property in JSON Pointer notation and the dataset from which that specific value originated. |
-| names                 	| struct	| The name associated with the feature. The first entry in the array of names must have a "local" language. |
-| level                 	| integer	| The building feature's Z-order, i.e., stacking order. A Z-order of 0 is ground level. |
-| is_underground        	| boolean	| Whether the entire building or part is completely below ground. This is useful for rendering which typically omits these buildings or styles them differently because they are not visible above ground. This is different than the level column which is used to indicate z-ordering of elements and negative values may be above ground. |
-| height                	| double	| Height of the building or part in meters. The height is the distance from the lowest point to the highest point. |
-| num_floors            	| integer	| Number of above-ground floors of the building or part. |
-| num_floors_underground	| integer	| Number of below-ground floors of the building or part. |
-| min_height            	| double	| The height of the bottom part of building in meters. Used if a building or part of building starts above the ground level. |
-| min_floor             	| integer	| The "start" floor of a building or building part. Indicates that the building or part is "floating" and its bottom-most floor is above ground level, usually because it is part of a larger building in which some parts do reach ground level. |
-| facade_color          	| string	| The color (name or color triplet) of the facade of a building or building part in hexadecimal. |
-| facade_material       	| string	| The outer surface material of building facade. |
-| roof_material         	| string	| The outermost material of the roof. |
-| roof_shape            	| string	| The shape of the roof. |
-| roof_direction        	| double	| Bearing of the roof ridge line. |
-| roof_orientation      	| string	| Orientation of the roof shape relative to the footprint shape. Either "along" or "across." |
-| roof_color            	| string	| The color (name or color triplet) of the roof of a building or building part in hexadecimal. |
-| roof_height           	| double	| The height of the building roof in meters. This represents the distance from the base of the roof to the highest point of the roof. |
-| building_id           	| string	| The building ID to which this part belongs. |
-| filename					| string	| Name of the file being queried. |
-| theme						| string	| Name of the Overture theme being queried. |
-| type						| string	| Name of the Overture feature type being queried. |
+| column | type | description |
+| --- | --- | --- |
+| id | string | A feature ID that may be associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
+| geometry | binary | A building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). MUST be a Polygon as defined by GeoJSON schema. |
+| bbox | struct | Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
+| version | integer | Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
+| sources | struct | The array of source information for the properties of a given feature. Each source object lists the property in JSON Pointer notation and the dataset from which that specific value originated. |
+| names | struct | The name associated with the feature. The first entry in the array of names must have a "local" language. |
+| level | integer | The building feature's Z-order, i.e., stacking order. A Z-order of 0 is ground level. |
+| is_underground | boolean | Whether the entire building or part is completely below ground. This is useful for rendering which typically omits these buildings or styles them differently because they are not visible above ground. This is different than the level column which is used to indicate z-ordering of elements and negative values may be above ground. |
+| height | double | Height of the building or part in meters. The height is the distance from the lowest point to the highest point. |
+| num_floors | integer | Number of above-ground floors of the building or part. |
+| num_floors_underground | integer | Number of below-ground floors of the building or part. |
+| min_height | double | The height of the bottom part of building in meters. Used if a building or part of building starts above the ground level. |
+| min_floor | integer | The "start" floor of a building or building part. Indicates that the building or part is "floating" and its bottom-most floor is above ground level, usually because it is part of a larger building in which some parts do reach ground level. |
+| facade_color | string | The color (name or color triplet) of the facade of a building or building part in hexadecimal. |
+| facade_material | string | The outer surface material of building facade. |
+| roof_material | string | The outermost material of the roof. |
+| roof_shape | string | The shape of the roof. |
+| roof_direction | double | Bearing of the roof ridge line. |
+| roof_orientation | string | Orientation of the roof shape relative to the footprint shape. Either "along" or "across." |
+| roof_color | string | The color (name or color triplet) of the roof of a building or building part in hexadecimal. |
+| roof_height | double | The height of the building roof in meters. This represents the distance from the base of the roof to the highest point of the roof. |
+| building_id | string | The building ID to which this part belongs. |
+| filename | string | Name of the file being queried. |
+| theme | string | Name of the Overture theme being queried. |
+| type | string | Name of the Overture feature type being queried. |
 
 </TabItem>
 </Tabs>

--- a/docs/guides/buildings.mdx
+++ b/docs/guides/buildings.mdx
@@ -49,13 +49,13 @@ If you have a particular geographic area of interest, there are several options 
 
 <figure>
   <BuildingsMap></BuildingsMap>
-  <!-- <ThemedImage
+  {/* <!-- <ThemedImage
     alt="Overture buildings in San Diego"
     sources={{
       light: useBaseUrl('/img/guides/buildings/san_diego_buildings_3.jpg'),
       dark: useBaseUrl('/img/guides/buildings/san_diego_buildings_3.jpg'),
     }}
-  /> -->
+  /> --> */}
   <figcaption>
   <div style={{'textAlign':'center'}}>
     <span style={{'backgroundColor':'rgb(36,39,47)', padding:2}}>

--- a/docs/guides/divisions.mdx
+++ b/docs/guides/divisions.mdx
@@ -80,7 +80,7 @@ Subtypes can represent each feature's administrative level, from `country` down 
 <TabItem value="division" label="division" default>
 
 | column | type | description |
-| --- | --- | --- | --- |
+| --- | --- | --- |
 | id | string | A feature ID. This may be an ID associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
 | geometry | binary | A WKB representation of the entity's geometry - a Point, Polygon, MultiPolygon, or LineString. |
 | bbox | struct | The bounding box of an entity's geometry, represented with float values, in a `xmin, xmax, ymin, ymax` format. |
@@ -109,7 +109,7 @@ Subtypes can represent each feature's administrative level, from `country` down 
 <TabItem value="division_area" label="division_area" default>
 
 | column | type | description |
-| --- | --- | --- | --- |
+| --- | --- | --- |
 | id | string | A feature ID. This may be an ID associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
 | geometry | binary | A WKB representation of the entity's geometry - a Point, Polygon, MultiPolygon, or LineString. |
 | bbox | struct | The bounding box of an entity's geometry, represented with float values, in a `xmin, xmax, ymin, ymax` format. |
@@ -131,7 +131,7 @@ Subtypes can represent each feature's administrative level, from `country` down 
 <TabItem value="division_boundary" label="division_boundary" default>
 
 | column | type | description |
-| --- | --- | --- | --- |
+| --- | --- | --- |
 | id | string | A feature ID. This may be an ID associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
 | geometry | binary | A WKB representation of the entity's geometry - a Point, Polygon, MultiPolygon, or LineString. |
 | bbox | struct | The bounding box of an entity's geometry, represented with float values, in a `xmin, xmax, ymin, ymax` format. |

--- a/docs/guides/divisions.mdx
+++ b/docs/guides/divisions.mdx
@@ -54,59 +54,105 @@ Subtypes can represent each feature's administrative level, from `country` down 
 <details>
 	<summary>List of all subtypes in the divisions theme</summary>
 
-| Subtype | Description | Example |
-| -------- | -------- | ------- |
-| **country** | Largest unit of independent sovereignty. | United States |
-| **dependency** | A place that is not exactly a sub-region of a country but is dependent on a parent company for defence, passport control, subsidies, etc. | Puerto Rico |
-| **macroregion** | A bundle of regions. These exist mainly in Europe. | Scotland; Île-de-France |
-| **region** | States, provinces, regions. Largest sub-country administrative unit most countries, unless they have dependencies/macroregions. | Alaska; Alberta |
-| **macrocounty** | A bundle of counties. Again, these exist mainly in Europe. | Inverness |
-| **county** | Counties... Largest sub-region administrative unit in most countries, unless they have macrocounties. | Kings County, NY |
-| **localadmin** | A level of government available in some parts of the world that contains localities or populated places that themselves have no authority. Often but not exclusively found in Europe. | Paris |
-| **locality** | A populated place that may or may not have its own administrative authority. (It won't if it belongs to a localadmin.) | Taipei |
-| **borough** | A local government unit, below the locality placetype. | Brooklyn, Queens, etc. |
-| **macrohood** | A super-neighborhood that contains smaller divisions of type neighborhood. | BoCoCa (Boerum Hill, Cobble Hill, and Carroll Gardens) |
-| **neighborhood** | A neighborhood. Most neighborhoods will be just this, unless there's enough granular division to warrant introducing macrohood and/or microhood divisions. | Cobble Hill |
-| **microhood** | A mini-neighborhood that is contained within a division of type neighborhood. | Gätjensort in Hamburg |
+| subtype			| description																																											| example |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| **country**		| Largest unit of independent sovereignty.																																				| United States |
+| **dependency**	| A place that is not exactly a sub-region of a country but is dependent on a parent company for defence, passport control, subsidies, etc.												| Puerto Rico |
+| **macroregion**	| A bundle of regions. These exist mainly in Europe.																																	| Scotland; Île-de-France |
+| **region**		| States, provinces, regions. Largest sub-country administrative unit most countries, unless they have dependencies/macroregions.														| Alaska; Alberta |
+| **macrocounty**	| A bundle of counties. Again, these exist mainly in Europe.																															| Inverness |
+| **county**		| Counties... Largest sub-region administrative unit in most countries, unless they have macrocounties.																					| Kings County, NY |
+| **localadmin**	| A level of government available in some parts of the world that contains localities or populated places that themselves have no authority. Often but not exclusively found in Europe. | Paris |
+| **locality**		| A populated place that may or may not have its own administrative authority. (It won't if it belongs to a localadmin.)																| Taipei |
+| **borough**		| A local government unit, below the locality placetype.																																| Brooklyn, Queens, etc. |
+| **macrohood**		| A super-neighborhood that contains smaller divisions of type neighborhood.																											| BoCoCa (Boerum Hill, Cobble Hill, and Carroll Gardens) |
+| **neighborhood**	| A neighborhood. Most neighborhoods will be just this, unless there's enough granular division to warrant introducing macrohood and/or microhood divisions.							| Cobble Hill |
+| **microhood**		| A mini-neighborhood that is contained within a division of type neighborhood.																											| Gätjensort in Hamburg |
+
 </details>
 
-### Data columns
-
-The divisions GeoParquet file contains the following properties:
+## Understanding the parquet files
 
 <details>
     <summary>Schema for the GeoParquet files in the divisions theme</summary>
+<div>
+<Tabs>
+<TabItem value="division" label="division" default>
 
-| Property Name | Type | Description |
-| -------- | -------- | ------- |
-| **id** |string | A feature ID. This may be an ID associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS.
-| **geometry** | blob | A WKB representation of the entity's geometry - a Point, Polygon, MultiPolygon, or LineString.
-| **bbox** | array | The bounding box of an entity's geometry, represented with float values, in a `xmin, xmax, ymin, ymax` format.
-| **version** | integer | Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed.
-| **sources** | array | The array of source information for the properties of a given feature, with each entry being a source object which lists the property in JSON Pointer notation and the dataset that specific value came from. All features must have a root level source which is the default source if a specific property's source is not specified.
-| **subtype** | string | Category of the division from a finite, hierarchical, ordered list of categories (e.g. country, region, locality, etc.) similar to a Who's on First placetype.
-| **wikidata** | string | A wikidata ID if available, as found on https://www.wikidata.org/.
-| **population** | integer | Population of the division.
-| **names** | array | A primary name of the entity, and a set of optional name translations. Name translations are represented in key, value pairs, where the key is an ISO language code and the value is the translated name.
-| **class** | string | A value to represent whether an entity represents a `maritime` or `land` feature.
-| **division_ids** | list | A list of the two division IDs that share this division boundary.
-| **is_disputed** | boolean | Indicator if there are entities disputing this division boundary. Information about entities disputing this boundary should be included in perspectives property. This property should also be true if boundary between two entities is unclear and this is "best guess". So having it true and no perspectives gives map creators reason not to fully trust the boundary, but use it if they have no other.
-| **perspectives** | array | Political perspectives from which this division boundary is considered to be an accurate representation. If this property is absent, then this boundary is not known to be disputed from any political perspective. Consequently, there is only one boundary feature representing the entire real world entity. If this property is present, it means the boundary represents one of several alternative perspectives on the same real-world entity.
-| **local_type** | string | Local name for the subtype property, optionally localized. This property is localized using a standard Overture names structure.
-| **country** | string | ISO 3166-1 alpha-2 country code of the country or country-like entity, that this division represents or belongs to. If the entity this division represents has a country code, the country property contains it. If it does not, the country property contains the country code of the first division encountered by traversing the parent_division_id chain to the root.
-| **region** | string | ISO 3166-2 principal subdivision code of the subdivision-like entity this division represents or belongs to. If the entity this division represents has a principal subdivision code, the region property contains it. If it does not, the region property contains the principal subdivision code of the first division encountered by traversing the parent_division_id chain to the root.
-| **hierarchies** | Array | Hierarchies in which this division participates.
-| **parent_division_id** | string | Division ID of this division's parent division. Not allowed for top-level divisions (countries) and required for all other divisions. The default parent division is the parent division as seen from the default political perspective, if there is one, and is otherwise chosen somewhat arbitrarily. The hierarchies property can be used to inspect the exhaustive list of parent divisions.
-| **norms** | list | Collects information about local norms and rules within the division that are generally useful for mapping and map-related use cases. If the norms property or a desired sub-property of the norms property is missing on a division, but at least one of its ancestor divisions has the norms property and the desired sub-property, then the value from the nearest ancestor division may be assumed.
-| **capital_division_ids** | array | Division IDs of this division's capital divisions. If present, this property will refer to the division IDs of the capital cities, county seats, etc. of a division.
-| **capital_of_divisions** | list | Division ID of the division that this feature is the capital of. If present, this property will refer to the division IDs of a parent county, region, country, etc.
-| **division_id** | string | Division ID of the division this area belongs to.
-| **cartography** | array | Contains a prominence property, which offers a suggestion for displaying Overture features at specific zoom levels based on it's importance and significance.
-| **is_land** | boolean | Indicates whether or not the feature geometry represents the non-maritime "land" boundary, which can be used for map rendering, cartographic display, and similar purposes.
-| **is_territorial** | boolean | Indicates whether or not the feature geometry represents the full territorial boundary or claim of a feature.
-| **filename** | string | Name of the S3 file being queried.
-| **theme** | string | Name of the Overture theme being queried.
-| **type** |  string | Name of the Overture feature type being queried.
+| column                 	| type    	| description |
+| ------------------------- | --------- | ----------- |
+| id						| string	| A feature ID. This may be an ID associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
+| geometry					| binary	| A WKB representation of the entity's geometry - a Point, Polygon, MultiPolygon, or LineString. |
+| bbox						| struct	| The bounding box of an entity's geometry, represented with float values, in a `xmin, xmax, ymin, ymax` format. |
+| country					| string	| ISO 3166-1 alpha-2 country code of the country or country-like entity, that this division represents or belongs to. If the entity this division represents has a country code, the country property contains it. If it does not, the country property contains the country code of the first division encountered by traversing the parent_division_id chain to the root. |
+| version					| integer	| Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
+| sources					| struct	| The array of source information for the properties of a given feature, with each entry being a source object which lists the property in JSON Pointer notation and the dataset that specific value came from. All features must have a root level source which is the default source if a specific property's source is not specified. |
+| cartography				| struct	| Contains a prominence property, which offers a suggestion for displaying Overture features at specific zoom levels based on it's importance and significance. |
+| subtype					| string	| Category of the division from a finite, hierarchical, ordered list of categories (e.g. country, region, locality, etc.) similar to a Who's on First placetype. |
+| class						| string	| A value to represent whether an entity represents a `maritime` or `land` feature. |
+| names						| struct	| A primary name of the entity, and a set of optional name translations. Name translations are represented in key, value pairs, where the key is an ISO language code and the value is the translated name. |
+| wikidata					| string	| A wikidata ID if available, as found on https://www.wikidata.org/. |
+| region					| string	| ISO 3166-2 principal subdivision code of the subdivision-like entity this division represents or belongs to. If the entity this division represents has a principal subdivision code, the region property contains it. If it does not, the region property contains the principal subdivision code of the first division encountered by traversing the parent_division_id chain to the root. |
+| perspectives				| struct	| Political perspectives from which this division boundary is considered to be an accurate representation. If this property is absent, then this boundary is not known to be disputed from any political perspective. Consequently, there is only one boundary feature representing the entire real world entity. If this property is present, it means the boundary represents one of several alternative perspectives on the same real-world entity. |
+| local_type				| string	| Local name for the subtype property, optionally localized. This property is localized using a standard Overture names structure. |
+| hierarchies				| struct	| Hierarchies in which this division participates. |
+| parent_division_id		| string	| Division ID of this division's parent division. Not allowed for top-level divisions (countries) and required for all other divisions. The default parent division is the parent division as seen from the default political perspective, if there is one, and is otherwise chosen somewhat arbitrarily. The hierarchies property can be used to inspect the exhaustive list of parent divisions. |
+| norms						| array		| Collects information about local norms and rules within the division that are generally useful for mapping and map-related use cases. If the norms property or a desired sub-property of the norms property is missing on a division, but at least one of its ancestor divisions has the norms property and the desired sub-property, then the value from the nearest ancestor division may be assumed. |
+| population				| integer	| Population of the division. |
+| capital_division_ids		| struct	| Division IDs of this division's capital divisions. If present, this property will refer to the division IDs of the capital cities, county seats, etc. of a division. |
+| capital_of_divisions		| array		| Division ID of the division that this feature is the capital of. If present, this property will refer to the division IDs of a parent county, region, country, etc. |
+| filename					| string	| Name of the file being queried. |
+| theme						| string	| Name of the Overture theme being queried. |
+| type						| string	| Name of the Overture feature type being queried. |
+
+</TabItem>
+<TabItem value="division_area" label="division_area" default>
+
+| column                 	| type    	| description |
+| ------------------------- | --------- | ----------- |
+| id						| string	| A feature ID. This may be an ID associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
+| geometry					| binary	| A WKB representation of the entity's geometry - a Point, Polygon, MultiPolygon, or LineString. |
+| bbox						| struct	| The bounding box of an entity's geometry, represented with float values, in a `xmin, xmax, ymin, ymax` format. |
+| country					| string	| ISO 3166-1 alpha-2 country code of the country or country-like entity, that this division represents or belongs to. If the entity this division represents has a country code, the country property contains it. If it does not, the country property contains the country code of the first division encountered by traversing the parent_division_id chain to the root. |
+| version					| integer	| Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
+| sources					| struct	| The array of source information for the properties of a given feature, with each entry being a source object which lists the property in JSON Pointer notation and the dataset that specific value came from. All features must have a root level source which is the default source if a specific property's source is not specified. |
+| subtype					| string	| Category of the division from a finite, hierarchical, ordered list of categories (e.g. country, region, locality, etc.) similar to a Who's on First placetype. |
+| class						| string	| A value to represent whether an entity represents a `maritime` or `land` feature. |
+| names						| struct	| A primary name of the entity, and a set of optional name translations. Name translations are represented in key, value pairs, where the key is an ISO language code and the value is the translated name. |
+| is_land					| boolean	| Indicates whether or not the feature geometry represents the non-maritime "land" boundary, which can be used for map rendering, cartographic display, and similar purposes. |
+| is_territorial			| boolean	| Indicates whether or not the feature geometry represents the full territorial boundary or claim of a feature. |
+| region					| string	| ISO 3166-2 principal subdivision code of the subdivision-like entity this division represents or belongs to. If the entity this division represents has a principal subdivision code, the region property contains it. If it does not, the region property contains the principal subdivision code of the first division encountered by traversing the parent_division_id chain to the root. |
+| division_id				| string	| Division ID of the division this area belongs to. |
+| filename					| string	| Name of the S3 file being queried. |
+| theme						| string	| Name of the Overture theme being queried. |
+| type						| string	| Name of the Overture feature type being queried. |
+
+</TabItem>
+<TabItem value="division_boundary" label="division_boundary" default>
+
+| column                 	| type    	| description |
+| ------------------------- | --------- | ----------- |
+| id						| string	| A feature ID. This may be an ID associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
+| geometry					| binary	| A WKB representation of the entity's geometry - a Point, Polygon, MultiPolygon, or LineString. |
+| bbox						| struct	| The bounding box of an entity's geometry, represented with float values, in a `xmin, xmax, ymin, ymax` format. |
+| country					| string	| ISO 3166-1 alpha-2 country code of the country or country-like entity, that this division represents or belongs to. If the entity this division represents has a country code, the country property contains it. If it does not, the country property contains the country code of the first division encountered by traversing the parent_division_id chain to the root. |
+| version					| integer	| Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
+| sources					| struct	| The array of source information for the properties of a given feature, with each entry being a source object which lists the property in JSON Pointer notation and the dataset that specific value came from. All features must have a root level source which is the default source if a specific property's source is not specified. |
+| subtype					| string	| Category of the division from a finite, hierarchical, ordered list of categories (e.g. country, region, locality, etc.) similar to a Who's on First placetype. |
+| class						| string	| A value to represent whether an entity represents a `maritime` or `land` feature. |
+| is_land					| boolean	| Indicates whether or not the feature geometry represents the non-maritime "land" boundary, which can be used for map rendering, cartographic display, and similar purposes. |
+| is_territorial			| boolean	| Indicates whether or not the feature geometry represents the full territorial boundary or claim of a feature. |
+| division_ids				| array		| A list of the two division IDs that share this division boundary. |
+| region					| string	| ISO 3166-2 principal subdivision code of the subdivision-like entity this division represents or belongs to. If the entity this division represents has a principal subdivision code, the region property contains it. If it does not, the region property contains the principal subdivision code of the first division encountered by traversing the parent_division_id chain to the root. |
+| is_disputed				| boolean	| Indicator if there are entities disputing this division boundary. Information about entities disputing this boundary should be included in perspectives property. This property should also be true if boundary between two entities is unclear and this is "best guess". So having it true and no perspectives gives map creators reason not to fully trust the boundary, but use it if they have no other. |
+| perspectives				| struct	| Political perspectives from which this division boundary is considered to be an accurate representation. If this property is absent, then this boundary is not known to be disputed from any political perspective. Consequently, there is only one boundary feature representing the entire real world entity. If this property is present, it means the boundary represents one of several alternative perspectives on the same real-world entity. |
+| filename					| string	| Name of the S3 file being queried. |
+| theme						| string	| Name of the Overture theme being queried. |
+| type						| string	| Name of the Overture feature type being queried. |
+
+</TabItem>
+</Tabs>
+</div>
 </details>
 
 ## Data access and retrieval

--- a/docs/guides/divisions.mdx
+++ b/docs/guides/divisions.mdx
@@ -54,20 +54,20 @@ Subtypes can represent each feature's administrative level, from `country` down 
 <details>
 	<summary>List of all subtypes in the divisions theme</summary>
 
-| subtype			| description																																											| example |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| **country**		| Largest unit of independent sovereignty.																																				| United States |
-| **dependency**	| A place that is not exactly a sub-region of a country but is dependent on a parent company for defence, passport control, subsidies, etc.												| Puerto Rico |
-| **macroregion**	| A bundle of regions. These exist mainly in Europe.																																	| Scotland; Île-de-France |
-| **region**		| States, provinces, regions. Largest sub-country administrative unit most countries, unless they have dependencies/macroregions.														| Alaska; Alberta |
-| **macrocounty**	| A bundle of counties. Again, these exist mainly in Europe.																															| Inverness |
-| **county**		| Counties... Largest sub-region administrative unit in most countries, unless they have macrocounties.																					| Kings County, NY |
-| **localadmin**	| A level of government available in some parts of the world that contains localities or populated places that themselves have no authority. Often but not exclusively found in Europe. | Paris |
-| **locality**		| A populated place that may or may not have its own administrative authority. (It won't if it belongs to a localadmin.)																| Taipei |
-| **borough**		| A local government unit, below the locality placetype.																																| Brooklyn, Queens, etc. |
-| **macrohood**		| A super-neighborhood that contains smaller divisions of type neighborhood.																											| BoCoCa (Boerum Hill, Cobble Hill, and Carroll Gardens) |
-| **neighborhood**	| A neighborhood. Most neighborhoods will be just this, unless there's enough granular division to warrant introducing macrohood and/or microhood divisions.							| Cobble Hill |
-| **microhood**		| A mini-neighborhood that is contained within a division of type neighborhood.																											| Gätjensort in Hamburg |
+| subtype | description | example |
+| --- | --- | --- |
+| **country** | Largest unit of independent sovereignty. | United States |
+| **dependency** | A place that is not exactly a sub-region of a country but is dependent on a parent company for defence, passport control, subsidies, etc. | Puerto Rico |
+| **macroregion** | A bundle of regions. These exist mainly in Europe. | Scotland; Île-de-France |
+| **region** | States, provinces, regions. Largest sub-country administrative unit most countries, unless they have dependencies/macroregions. | Alaska; Alberta |
+| **macrocounty** | A bundle of counties. Again, these exist mainly in Europe. | Inverness |
+| **county** | Counties... Largest sub-region administrative unit in most countries, unless they have macrocounties. | Kings County, NY |
+| **localadmin** | A level of government available in some parts of the world that contains localities or populated places that themselves have no authority. Often but not exclusively found in Europe. | Paris |
+| **locality** | A populated place that may or may not have its own administrative authority. (It won't if it belongs to a localadmin.) | Taipei |
+| **borough** | A local government unit, below the locality placetype. | Brooklyn, Queens, etc. |
+| **macrohood** | A super-neighborhood that contains smaller divisions of type neighborhood. | BoCoCa (Boerum Hill, Cobble Hill, and Carroll Gardens) |
+| **neighborhood** | A neighborhood. Most neighborhoods will be just this, unless there's enough granular division to warrant introducing macrohood and/or microhood divisions. | Cobble Hill |
+| **microhood** | A mini-neighborhood that is contained within a division of type neighborhood. | Gätjensort in Hamburg |
 
 </details>
 
@@ -79,76 +79,76 @@ Subtypes can represent each feature's administrative level, from `country` down 
 <Tabs>
 <TabItem value="division" label="division" default>
 
-| column                 	| type    	| description |
-| ------------------------- | --------- | ----------- |
-| id						| string	| A feature ID. This may be an ID associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
-| geometry					| binary	| A WKB representation of the entity's geometry - a Point, Polygon, MultiPolygon, or LineString. |
-| bbox						| struct	| The bounding box of an entity's geometry, represented with float values, in a `xmin, xmax, ymin, ymax` format. |
-| country					| string	| ISO 3166-1 alpha-2 country code of the country or country-like entity, that this division represents or belongs to. If the entity this division represents has a country code, the country property contains it. If it does not, the country property contains the country code of the first division encountered by traversing the parent_division_id chain to the root. |
-| version					| integer	| Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
-| sources					| struct	| The array of source information for the properties of a given feature, with each entry being a source object which lists the property in JSON Pointer notation and the dataset that specific value came from. All features must have a root level source which is the default source if a specific property's source is not specified. |
-| cartography				| struct	| Contains a prominence property, which offers a suggestion for displaying Overture features at specific zoom levels based on it's importance and significance. |
-| subtype					| string	| Category of the division from a finite, hierarchical, ordered list of categories (e.g. country, region, locality, etc.) similar to a Who's on First placetype. |
-| class						| string	| A value to represent whether an entity represents a `maritime` or `land` feature. |
-| names						| struct	| A primary name of the entity, and a set of optional name translations. Name translations are represented in key, value pairs, where the key is an ISO language code and the value is the translated name. |
-| wikidata					| string	| A wikidata ID if available, as found on https://www.wikidata.org/. |
-| region					| string	| ISO 3166-2 principal subdivision code of the subdivision-like entity this division represents or belongs to. If the entity this division represents has a principal subdivision code, the region property contains it. If it does not, the region property contains the principal subdivision code of the first division encountered by traversing the parent_division_id chain to the root. |
-| perspectives				| struct	| Political perspectives from which this division boundary is considered to be an accurate representation. If this property is absent, then this boundary is not known to be disputed from any political perspective. Consequently, there is only one boundary feature representing the entire real world entity. If this property is present, it means the boundary represents one of several alternative perspectives on the same real-world entity. |
-| local_type				| string	| Local name for the subtype property, optionally localized. This property is localized using a standard Overture names structure. |
-| hierarchies				| struct	| Hierarchies in which this division participates. |
-| parent_division_id		| string	| Division ID of this division's parent division. Not allowed for top-level divisions (countries) and required for all other divisions. The default parent division is the parent division as seen from the default political perspective, if there is one, and is otherwise chosen somewhat arbitrarily. The hierarchies property can be used to inspect the exhaustive list of parent divisions. |
-| norms						| array		| Collects information about local norms and rules within the division that are generally useful for mapping and map-related use cases. If the norms property or a desired sub-property of the norms property is missing on a division, but at least one of its ancestor divisions has the norms property and the desired sub-property, then the value from the nearest ancestor division may be assumed. |
-| population				| integer	| Population of the division. |
-| capital_division_ids		| struct	| Division IDs of this division's capital divisions. If present, this property will refer to the division IDs of the capital cities, county seats, etc. of a division. |
-| capital_of_divisions		| array		| Division ID of the division that this feature is the capital of. If present, this property will refer to the division IDs of a parent county, region, country, etc. |
-| filename					| string	| Name of the file being queried. |
-| theme						| string	| Name of the Overture theme being queried. |
-| type						| string	| Name of the Overture feature type being queried. |
+| column | type | description |
+| --- | --- | --- | --- |
+| id | string | A feature ID. This may be an ID associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
+| geometry | binary | A WKB representation of the entity's geometry - a Point, Polygon, MultiPolygon, or LineString. |
+| bbox | struct | The bounding box of an entity's geometry, represented with float values, in a `xmin, xmax, ymin, ymax` format. |
+| country | string | ISO 3166-1 alpha-2 country code of the country or country-like entity, that this division represents or belongs to. If the entity this division represents has a country code, the country property contains it. If it does not, the country property contains the country code of the first division encountered by traversing the parent_division_id chain to the root. |
+| version | integer | Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
+| sources | struct | The array of source information for the properties of a given feature, with each entry being a source object which lists the property in JSON Pointer notation and the dataset that specific value came from. All features must have a root level source which is the default source if a specific property's source is not specified. |
+| cartography | struct | Contains a prominence property, which offers a suggestion for displaying Overture features at specific zoom levels based on it's importance and significance. |
+| subtype | string | Category of the division from a finite, hierarchical, ordered list of categories (e.g. country, region, locality, etc.) similar to a Who's on First placetype. |
+| class | string | A value to represent whether an entity represents a `maritime` or `land` feature. |
+| names | struct | A primary name of the entity, and a set of optional name translations. Name translations are represented in key, value pairs, where the key is an ISO language code and the value is the translated name. |
+| wikidata | string | A wikidata ID if available, as found on https://www.wikidata.org/. |
+| region | string | ISO 3166-2 principal subdivision code of the subdivision-like entity this division represents or belongs to. If the entity this division represents has a principal subdivision code, the region property contains it. If it does not, the region property contains the principal subdivision code of the first division encountered by traversing the parent_division_id chain to the root. |
+| perspectives | struct | Political perspectives from which this division boundary is considered to be an accurate representation. If this property is absent, then this boundary is not known to be disputed from any political perspective. Consequently, there is only one boundary feature representing the entire real world entity. If this property is present, it means the boundary represents one of several alternative perspectives on the same real-world entity. |
+| local_type | string | Local name for the subtype property, optionally localized. This property is localized using a standard Overture names structure. |
+| hierarchies | struct | Hierarchies in which this division participates. |
+| parent_division_id | string | Division ID of this division's parent division. Not allowed for top-level divisions (countries) and required for all other divisions. The default parent division is the parent division as seen from the default political perspective, if there is one, and is otherwise chosen somewhat arbitrarily. The hierarchies property can be used to inspect the exhaustive list of parent divisions. |
+| norms | array | Collects information about local norms and rules within the division that are generally useful for mapping and map-related use cases. If the norms property or a desired sub-property of the norms property is missing on a division, but at least one of its ancestor divisions has the norms property and the desired sub-property, then the value from the nearest ancestor division may be assumed. |
+| population | integer | Population of the division. |
+| capital_division_ids | struct | Division IDs of this division's capital divisions. If present, this property will refer to the division IDs of the capital cities, county seats, etc. of a division. |
+| capital_of_divisions | array | Division ID of the division that this feature is the capital of. If present, this property will refer to the division IDs of a parent county, region, country, etc. |
+| filename | string | Name of the file being queried. |
+| theme | string | Name of the Overture theme being queried. |
+| type | string | Name of the Overture feature type being queried. |
 
 </TabItem>
 <TabItem value="division_area" label="division_area" default>
 
-| column                 	| type    	| description |
-| ------------------------- | --------- | ----------- |
-| id						| string	| A feature ID. This may be an ID associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
-| geometry					| binary	| A WKB representation of the entity's geometry - a Point, Polygon, MultiPolygon, or LineString. |
-| bbox						| struct	| The bounding box of an entity's geometry, represented with float values, in a `xmin, xmax, ymin, ymax` format. |
-| country					| string	| ISO 3166-1 alpha-2 country code of the country or country-like entity, that this division represents or belongs to. If the entity this division represents has a country code, the country property contains it. If it does not, the country property contains the country code of the first division encountered by traversing the parent_division_id chain to the root. |
-| version					| integer	| Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
-| sources					| struct	| The array of source information for the properties of a given feature, with each entry being a source object which lists the property in JSON Pointer notation and the dataset that specific value came from. All features must have a root level source which is the default source if a specific property's source is not specified. |
-| subtype					| string	| Category of the division from a finite, hierarchical, ordered list of categories (e.g. country, region, locality, etc.) similar to a Who's on First placetype. |
-| class						| string	| A value to represent whether an entity represents a `maritime` or `land` feature. |
-| names						| struct	| A primary name of the entity, and a set of optional name translations. Name translations are represented in key, value pairs, where the key is an ISO language code and the value is the translated name. |
-| is_land					| boolean	| Indicates whether or not the feature geometry represents the non-maritime "land" boundary, which can be used for map rendering, cartographic display, and similar purposes. |
-| is_territorial			| boolean	| Indicates whether or not the feature geometry represents the full territorial boundary or claim of a feature. |
-| region					| string	| ISO 3166-2 principal subdivision code of the subdivision-like entity this division represents or belongs to. If the entity this division represents has a principal subdivision code, the region property contains it. If it does not, the region property contains the principal subdivision code of the first division encountered by traversing the parent_division_id chain to the root. |
-| division_id				| string	| Division ID of the division this area belongs to. |
-| filename					| string	| Name of the S3 file being queried. |
-| theme						| string	| Name of the Overture theme being queried. |
-| type						| string	| Name of the Overture feature type being queried. |
+| column | type | description |
+| --- | --- | --- | --- |
+| id | string | A feature ID. This may be an ID associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
+| geometry | binary | A WKB representation of the entity's geometry - a Point, Polygon, MultiPolygon, or LineString. |
+| bbox | struct | The bounding box of an entity's geometry, represented with float values, in a `xmin, xmax, ymin, ymax` format. |
+| country | string | ISO 3166-1 alpha-2 country code of the country or country-like entity, that this division represents or belongs to. If the entity this division represents has a country code, the country property contains it. If it does not, the country property contains the country code of the first division encountered by traversing the parent_division_id chain to the root. |
+| version | integer | Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
+| sources | struct | The array of source information for the properties of a given feature, with each entry being a source object which lists the property in JSON Pointer notation and the dataset that specific value came from. All features must have a root level source which is the default source if a specific property's source is not specified. |
+| subtype | string | Category of the division from a finite, hierarchical, ordered list of categories (e.g. country, region, locality, etc.) similar to a Who's on First placetype. |
+| class | string | A value to represent whether an entity represents a `maritime` or `land` feature. |
+| names | struct | A primary name of the entity, and a set of optional name translations. Name translations are represented in key, value pairs, where the key is an ISO language code and the value is the translated name. |
+| is_land | boolean | Indicates whether or not the feature geometry represents the non-maritime "land" boundary, which can be used for map rendering, cartographic display, and similar purposes. |
+| is_territorial | boolean | Indicates whether or not the feature geometry represents the full territorial boundary or claim of a feature. |
+| region | string | ISO 3166-2 principal subdivision code of the subdivision-like entity this division represents or belongs to. If the entity this division represents has a principal subdivision code, the region property contains it. If it does not, the region property contains the principal subdivision code of the first division encountered by traversing the parent_division_id chain to the root. |
+| division_id | string | Division ID of the division this area belongs to. |
+| filename | string | Name of the S3 file being queried. |
+| theme | string | Name of the Overture theme being queried. |
+| type | string | Name of the Overture feature type being queried. |
 
 </TabItem>
 <TabItem value="division_boundary" label="division_boundary" default>
 
-| column                 	| type    	| description |
-| ------------------------- | --------- | ----------- |
-| id						| string	| A feature ID. This may be an ID associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
-| geometry					| binary	| A WKB representation of the entity's geometry - a Point, Polygon, MultiPolygon, or LineString. |
-| bbox						| struct	| The bounding box of an entity's geometry, represented with float values, in a `xmin, xmax, ymin, ymax` format. |
-| country					| string	| ISO 3166-1 alpha-2 country code of the country or country-like entity, that this division represents or belongs to. If the entity this division represents has a country code, the country property contains it. If it does not, the country property contains the country code of the first division encountered by traversing the parent_division_id chain to the root. |
-| version					| integer	| Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
-| sources					| struct	| The array of source information for the properties of a given feature, with each entry being a source object which lists the property in JSON Pointer notation and the dataset that specific value came from. All features must have a root level source which is the default source if a specific property's source is not specified. |
-| subtype					| string	| Category of the division from a finite, hierarchical, ordered list of categories (e.g. country, region, locality, etc.) similar to a Who's on First placetype. |
-| class						| string	| A value to represent whether an entity represents a `maritime` or `land` feature. |
-| is_land					| boolean	| Indicates whether or not the feature geometry represents the non-maritime "land" boundary, which can be used for map rendering, cartographic display, and similar purposes. |
-| is_territorial			| boolean	| Indicates whether or not the feature geometry represents the full territorial boundary or claim of a feature. |
-| division_ids				| array		| A list of the two division IDs that share this division boundary. |
-| region					| string	| ISO 3166-2 principal subdivision code of the subdivision-like entity this division represents or belongs to. If the entity this division represents has a principal subdivision code, the region property contains it. If it does not, the region property contains the principal subdivision code of the first division encountered by traversing the parent_division_id chain to the root. |
-| is_disputed				| boolean	| Indicator if there are entities disputing this division boundary. Information about entities disputing this boundary should be included in perspectives property. This property should also be true if boundary between two entities is unclear and this is "best guess". So having it true and no perspectives gives map creators reason not to fully trust the boundary, but use it if they have no other. |
-| perspectives				| struct	| Political perspectives from which this division boundary is considered to be an accurate representation. If this property is absent, then this boundary is not known to be disputed from any political perspective. Consequently, there is only one boundary feature representing the entire real world entity. If this property is present, it means the boundary represents one of several alternative perspectives on the same real-world entity. |
-| filename					| string	| Name of the S3 file being queried. |
-| theme						| string	| Name of the Overture theme being queried. |
-| type						| string	| Name of the Overture feature type being queried. |
+| column | type | description |
+| --- | --- | --- | --- |
+| id | string | A feature ID. This may be an ID associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
+| geometry | binary | A WKB representation of the entity's geometry - a Point, Polygon, MultiPolygon, or LineString. |
+| bbox | struct | The bounding box of an entity's geometry, represented with float values, in a `xmin, xmax, ymin, ymax` format. |
+| country | string | ISO 3166-1 alpha-2 country code of the country or country-like entity, that this division represents or belongs to. If the entity this division represents has a country code, the country property contains it. If it does not, the country property contains the country code of the first division encountered by traversing the parent_division_id chain to the root. |
+| version | integer | Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
+| sources | struct | The array of source information for the properties of a given feature, with each entry being a source object which lists the property in JSON Pointer notation and the dataset that specific value came from. All features must have a root level source which is the default source if a specific property's source is not specified. |
+| subtype | string | Category of the division from a finite, hierarchical, ordered list of categories (e.g. country, region, locality, etc.) similar to a Who's on First placetype. |
+| class | string | A value to represent whether an entity represents a `maritime` or `land` feature. |
+| is_land | boolean | Indicates whether or not the feature geometry represents the non-maritime "land" boundary, which can be used for map rendering, cartographic display, and similar purposes. |
+| is_territorial | boolean | Indicates whether or not the feature geometry represents the full territorial boundary or claim of a feature. |
+| division_ids | array | A list of the two division IDs that share this division boundary. |
+| region | string | ISO 3166-2 principal subdivision code of the subdivision-like entity this division represents or belongs to. If the entity this division represents has a principal subdivision code, the region property contains it. If it does not, the region property contains the principal subdivision code of the first division encountered by traversing the parent_division_id chain to the root. |
+| is_disputed | boolean | Indicator if there are entities disputing this division boundary. Information about entities disputing this boundary should be included in perspectives property. This property should also be true if boundary between two entities is unclear and this is "best guess". So having it true and no perspectives gives map creators reason not to fully trust the boundary, but use it if they have no other. |
+| perspectives | struct | Political perspectives from which this division boundary is considered to be an accurate representation. If this property is absent, then this boundary is not known to be disputed from any political perspective. Consequently, there is only one boundary feature representing the entire real world entity. If this property is present, it means the boundary represents one of several alternative perspectives on the same real-world entity. |
+| filename | string | Name of the S3 file being queried. |
+| theme | string | Name of the Overture theme being queried. |
+| type | string | Name of the Overture feature type being queried. |
 
 </TabItem>
 </Tabs>
@@ -161,20 +161,20 @@ Overture's divisions theme data is freely available on both Amazon S3 and Micros
 
 <Tabs>
   <TabItem value="division" label="division">
-    | Provider | Location |
-    | -------- | -------- |
+    | provider | location |
+    | --- | --- |
     | Amazon S3 | <QueryBuilder query="s3://overturemaps-us-west-2/release/__OVERTURE_RELEASE/theme=divisions/type=division/*" language="text"></QueryBuilder> |
     | Azure Blob Storage | <QueryBuilder query="https://overturemapswestus2.blob.core.windows.net/release/__OVERTURE_RELEASE/theme=divisions/type=division/*" language="text"></QueryBuilder> |
   </TabItem>
   <TabItem value="division_area" label="division_area">
-    | Provider | Location |
-    | -------- | -------- |
+    | provider | location |
+    | --- | --- |
     | Amazon S3 | <QueryBuilder query="s3://overturemaps-us-west-2/release/__OVERTURE_RELEASE/theme=divisions/type=division_area/*" language="text"></QueryBuilder> |
     | Azure Blob Storage | <QueryBuilder query="https://overturemapswestus2.blob.core.windows.net/release/__OVERTURE_RELEASE/theme=divisions/type=division_area/*" language="text"></QueryBuilder> |
   </TabItem>
   <TabItem value="division_boundary" label="division_boundary">
-    | Provider | Location |
-    | -------- | -------- |
+    | provider | location |
+    | --- | --- |
     | Amazon S3 | <QueryBuilder query="s3://overturemaps-us-west-2/release/__OVERTURE_RELEASE/theme=divisions/type=division_boundary/*" language="text"></QueryBuilder> |
     | Azure Blob Storage | <QueryBuilder query="https://overturemapswestus2.blob.core.windows.net/release/__OVERTURE_RELEASE/theme=divisions/type=division_boundary/*" language="text"></QueryBuilder> |
   </TabItem>

--- a/docs/guides/places.mdx
+++ b/docs/guides/places.mdx
@@ -28,19 +28,19 @@ The Overture places theme has one feature type, called `place`, and contains mor
 |:--:|
 | *Overture places data, June 2025* |
 
-| source					|  feature count, june 2025 |
-| ------------------------- | --------------------- |
-| meta						| 56,677,393 |
-| Microsoft					| 4,655,498 |
-| Microsoft & meta			| 2,891,357 |
-| Microsoft & PinMeTo		| 48,157 |
-| PinMeTo					| 44,506 |
-| Microsoft, PinMeTo & meta	| 31,546 |
-| Krick & Microsoft			| 6,306 |
-| PinMeTo & meta			| 5,835 |
-| Krick						| 3,199 |
-| Krick, Microsoft & meta	| 2,690 |
-| Krick & meta				| 723 |
+| source | feature count, june 2025 |
+| --- | --- |
+| meta | 56,677,393 |
+| Microsoft | 4,655,498 |
+| Microsoft & meta | 2,891,357 |
+| Microsoft & PinMeTo | 48,157 |
+| PinMeTo | 44,506 |
+| Microsoft, PinMeTo & meta | 31,546 |
+| Krick & Microsoft | 6,306 |
+| PinMeTo & meta | 5,835 |
+| Krick | 3,199 |
+| Krick, Microsoft & meta | 2,690 |
+| Krick & meta | 723 |
 
 ## Dataset description
 
@@ -50,25 +50,25 @@ All Overture data, including places data, is distributed as GeoParquet, a column
     <summary>Schema for GeoParquet files in the places theme</summary>
 <div>
 
-| column                 	| type    	| description |
-| ------------------------- | --------- | ----------- |
-| id						| string	| A feature ID. This may be an ID associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
-| geometry					| binary	| The point representation of the Place's location. Place's geometry which MUST be a Point as defined by GeoJSON schema. |
-| bbox						| struct	| Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
-| version					| integer	| Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
-| sources					| struct	| The array of source information for the properties of a given feature, with each entry being a source object which lists the property in JSON Pointer notation and the dataset that specific value came from. All features must have a root level source which is the default source if a specific property's source is not specified. |
-| names						| struct	| Properties defining the names of a feature. |
-| categories				| struct	| The categories of the place. Complete list is available on GitHub: https://github.com/OvertureMaps/schema/blob/main/docs/schema/concepts/by-theme/places/overture_categories.csv |
-| confidence				| double	| The confidence of the existence of the place. It's a number between 0 and 1. 0 means that we're sure that the place doesn't exist (anymore). 1 means that we're sure that the place exists. If there's no value for the confidence, it means that we don't have any confidence information. |
-| websites					| string	| The websites of the place. |
-| socials					| string	| The social media URLs of the place. |
-| emails					| string	| The email addresses of the place. |
-| phones					| string	| The phone numbers of the place. |
-| brand						| struct	| The brand of the place. A location with multiple brands is modeled as multiple separate places, each with its own brand. |
-| addresses					| struct	| The addresses of the place. |
-| filename					| string	| Name of the file being queried. |
-| theme						| string	| Name of the Overture theme being queried. |
-| type						| string	| Name of the Overture feature type being queried. |
+| column | type | description |
+| --- | --- | --- | --- |
+| id | string | A feature ID. This may be an ID associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
+| geometry | binary | The point representation of the Place's location. Place's geometry which MUST be a Point as defined by GeoJSON schema. |
+| bbox | struct | Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
+| version | integer | Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
+| sources | struct | The array of source information for the properties of a given feature, with each entry being a source object which lists the property in JSON Pointer notation and the dataset that specific value came from. All features must have a root level source which is the default source if a specific property's source is not specified. |
+| names | struct | Properties defining the names of a feature. |
+| categories | struct | The categories of the place. Complete list is available on GitHub: https://github.com/OvertureMaps/schema/blob/main/docs/schema/concepts/by-theme/places/overture_categories.csv |
+| confidence | double | The confidence of the existence of the place. It's a number between 0 and 1. 0 means that we're sure that the place doesn't exist (anymore). 1 means that we're sure that the place exists. If there's no value for the confidence, it means that we don't have any confidence information. |
+| websites | string | The websites of the place. |
+| socials | string | The social media URLs of the place. |
+| emails | string | The email addresses of the place. |
+| phones | string | The phone numbers of the place. |
+| brand | struct | The brand of the place. A location with multiple brands is modeled as multiple separate places, each with its own brand. |
+| addresses | struct | The addresses of the place. |
+| filename | string | Name of the file being queried. |
+| theme | string | Name of the Overture theme being queried. |
+| type | string | Name of the Overture feature type being queried. |
 
 </div>
 </details>
@@ -77,8 +77,8 @@ All Overture data, including places data, is distributed as GeoParquet, a column
 
 Overture's places theme data is freely available on both Amazon S3 and Microsoft Azure Blob Storage at these locations:
 
-| Provider | Location |
-| ------ | -------- |
+| provider | location |
+| --- | --- |
 | Amazon S3 | <QueryBuilder query="s3://overturemaps-us-west-2/release/__OVERTURE_RELEASE/theme=places/type=place/*" language="text"></QueryBuilder>|
 | Azure Blob Storage | <QueryBuilder query="https://overturemapswestus2.blob.core.windows.net/release/__OVERTURE_RELEASE/theme=places/type=place/*" language="text"></QueryBuilder> |
 

--- a/docs/guides/places.mdx
+++ b/docs/guides/places.mdx
@@ -28,18 +28,18 @@ The Overture places theme has one feature type, called `place`, and contains mor
 |:--:|
 | *Overture places data, June 2025* |
 
-| source | feature count, june 2025 |
+| source | feature count, June 2025 |
 | --- | --- |
 | meta | 56,677,393 |
 | Microsoft | 4,655,498 |
-| Microsoft & meta | 2,891,357 |
+| meta & Microsoft | 2,891,357 |
 | Microsoft & PinMeTo | 48,157 |
 | PinMeTo | 44,506 |
-| Microsoft, PinMeTo & meta | 31,546 |
+| meta, Microsoft & PinMeTo | 31,546 |
 | Krick & Microsoft | 6,306 |
-| PinMeTo & meta | 5,835 |
+| meta & PinMeTo | 5,835 |
 | Krick | 3,199 |
-| Krick, Microsoft & meta | 2,690 |
+| Krick, meta & Microsoft | 2,690 |
 | Krick & meta | 723 |
 
 ## Dataset description
@@ -51,7 +51,7 @@ All Overture data, including places data, is distributed as GeoParquet, a column
 <div>
 
 | column | type | description |
-| --- | --- | --- | --- |
+| --- | --- | --- |
 | id | string | A feature ID. This may be an ID associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
 | geometry | binary | The point representation of the Place's location. Place's geometry which MUST be a Point as defined by GeoJSON schema. |
 | bbox | struct | Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |

--- a/docs/guides/places.mdx
+++ b/docs/guides/places.mdx
@@ -1,7 +1,8 @@
 ---
 title: Places
-description: 61M+ places and points of interest around the world
+description: 64M+ places and points of interest around the world
 ---
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import QueryBuilder from '@site/src/components/queryBuilder';
@@ -27,19 +28,19 @@ The Overture places theme has one feature type, called `place`, and contains mor
 |:--:|
 | *Overture places data, June 2025* |
 
-| Source |  Feature count, June 2025 release |
-| -------------------------- | --------------------- |
-| meta | 56,677,393 |
-| Microsoft | 4,655,498 |
-| Microsoft & meta | 2,891,357 |
-| Microsoft & PinMeTo | 48,157 |
-| PinMeTo | 44,506 |
-| Microsoft, PinMeTo & meta | 31,546 |
-| Krick & Microsoft | 6,306 |
-| PinMeTo & meta | 5,835 |
-| Krick | 3,199 |
-| Krick, Microsoft & meta | 2,690 |
-| Krick & meta | 723 |
+| source					|  feature count, june 2025 |
+| ------------------------- | --------------------- |
+| meta						| 56,677,393 |
+| Microsoft					| 4,655,498 |
+| Microsoft & meta			| 2,891,357 |
+| Microsoft & PinMeTo		| 48,157 |
+| PinMeTo					| 44,506 |
+| Microsoft, PinMeTo & meta	| 31,546 |
+| Krick & Microsoft			| 6,306 |
+| PinMeTo & meta			| 5,835 |
+| Krick						| 3,199 |
+| Krick, Microsoft & meta	| 2,690 |
+| Krick & meta				| 723 |
 
 ## Dataset description
 
@@ -48,29 +49,29 @@ All Overture data, including places data, is distributed as GeoParquet, a column
 <details>
     <summary>Schema for GeoParquet files in the places theme</summary>
 <div>
-<Tabs>
-<TabItem value="places" label="places" default>
-| column | type | description |
-|---|---|---|
-| id | VARCHAR | A feature ID. This may be an ID associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
-| geometry | BLOB | The point representation of the Place's location. Place's geometry which MUST be a Point as defined by GeoJSON schema. |
-| bbox | STRUCT | Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
-| version | INTEGER | Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
-| sources | STRUCT | The array of source information for the properties of a given feature, with each entry being a source object which lists the property in JSON Pointer notation and the dataset that specific value came from. All features must have a root level source which is the default source if a specific property's source is not specified. |
-| names | STRUCT | Properties defining the names of a feature. |
-| categories | STRUCT | The categories of the place. Complete list is available on GitHub: https://github.com/OvertureMaps/schema/blob/main/docs/schema/concepts/by-theme/places/overture_categories.csv |
-| confidence | DOUBLE | The confidence of the existence of the place. It's a number between 0 and 1. 0 means that we're sure that the place doesn't exist (anymore). 1 means that we're sure that the place exists. If there's no value for the confidence, it means that we don't have any confidence information. |
-| websites | VARCHAR[] | The websites of the place. |
-| socials | VARCHAR[] | The social media URLs of the place. |
-| emails | VARCHAR[] | The email addresses of the place. |
-| phones | VARCHAR[] | The phone numbers of the place. |
-| brand | STRUCT | The brand of the place. A location with multiple brands is modeled as multiple separate places, each with its own brand. |
-| addresses | STRUCT | The addresses of the place. |
-</TabItem>
-</Tabs>
+
+| column                 	| type    	| description |
+| ------------------------- | --------- | ----------- |
+| id						| string	| A feature ID. This may be an ID associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
+| geometry					| binary	| The point representation of the Place's location. Place's geometry which MUST be a Point as defined by GeoJSON schema. |
+| bbox						| struct	| Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
+| version					| integer	| Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
+| sources					| struct	| The array of source information for the properties of a given feature, with each entry being a source object which lists the property in JSON Pointer notation and the dataset that specific value came from. All features must have a root level source which is the default source if a specific property's source is not specified. |
+| names						| struct	| Properties defining the names of a feature. |
+| categories				| struct	| The categories of the place. Complete list is available on GitHub: https://github.com/OvertureMaps/schema/blob/main/docs/schema/concepts/by-theme/places/overture_categories.csv |
+| confidence				| double	| The confidence of the existence of the place. It's a number between 0 and 1. 0 means that we're sure that the place doesn't exist (anymore). 1 means that we're sure that the place exists. If there's no value for the confidence, it means that we don't have any confidence information. |
+| websites					| string	| The websites of the place. |
+| socials					| string	| The social media URLs of the place. |
+| emails					| string	| The email addresses of the place. |
+| phones					| string	| The phone numbers of the place. |
+| brand						| struct	| The brand of the place. A location with multiple brands is modeled as multiple separate places, each with its own brand. |
+| addresses					| struct	| The addresses of the place. |
+| filename					| string	| Name of the file being queried. |
+| theme						| string	| Name of the Overture theme being queried. |
+| type						| string	| Name of the Overture feature type being queried. |
+
 </div>
 </details>
-
 
 ## Data access and retrieval
 

--- a/docs/guides/transportation.mdx
+++ b/docs/guides/transportation.mdx
@@ -2,6 +2,7 @@
 title: Transportation
 description: Global road, rail, and water transportation data
 ---
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import QueryBuilder from '@site/src/components/queryBuilder';
@@ -10,7 +11,6 @@ import ParkingAisles from '!!raw-loader!@site/src/queries/duckdb/transportation_
 import Routes from '!!raw-loader!@site/src/queries/duckdb/transportation_routes.sql';
 import SpeedLimits from '!!raw-loader!@site/src/queries/athena/transportation_speed_limits.sql';
 import ConnectingSegments from '!!raw-loader!@site/src/queries/athena/transportation_connecting_segments.sql';
-
 
 ## Overview
 
@@ -42,38 +42,48 @@ All Overture data, including transportation data, is distributed as GeoParquet, 
 <div>
 <Tabs>
 <TabItem value="segment" label="segment" default>
-| column_name | column_type | Description |
-|---|---|---|
-| id | VARCHAR | A feature ID. This may be an ID associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
-| geometry | WKB | The line representation of the segment's location. Segment's geometry which MUST be a LineSting as defined by GeoJSON schema. |
-| bbox | STRUCT | Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
-| version | INTEGER | Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
-| sources | STRUCT[] | The array of source information for the properties of a given feature, with each entry being a source object which lists the property in JSON Pointer notation and the dataset that specific value came from. All features must have a root level source which is the default source if a specific property's source is not specified. |
-| subtype | VARCHAR | The broad category of transportation segment. |
-| class | VARCHAR | Captures the kind of road and its position in the road network hierarchy. |
-| subclass | VARCHAR | Specifies the usage of a length of road. |
-| subclass_rules | STRUCT[] | Defines the portion of a road that the subclass applies to. |
-| names | STRUCT[] | Properties defining the names of a feature. |
-| connectors | STRUCT[] | Array of connector IDs identifying the connectors this segment is physically connected to linearly referenced with their location. Each connector is a possible routing decision point, meaning it defines a place along the segment in which there is possibility to transition to other segments which share the same connector. |
-| routes | STRUCT[] | Routes this segment belongs to. |
-| access_restrictions | STRUCT[] | Rules governing access to this road segment or lane. |
-| level_rules | STRUCT[] | Defines the Z-order, i.e. stacking order, of the road segment. |
-| prohibited_transitions | STRUCT[] | Defines where traveling from the segment to another is disallowed for navigation. This covers things situations prohibited turns or a transition from road to bike lane disallowing cars. |
-| road_surface | STRUCT[] | Defines the surface material on a road such as paved, asphalt, or unpaved. |
-| road_flags | STRUCT[] | Additional properties relevant to roads such as is_bridge or is_under_construction. |
-| rail_flags | STRUCT[] | Additional properties relevant to rail such as is_tunnel or is_freight. |
-| speed_limits | STRUCT[] | Defines the speed limit of the road segment. |
-| width_rules | STRUCT[] | Defines the width of the road segment for rendering. |
-| destinations | STRUCT[] | Describes the transitions from one segment to another on the way to a specified location. This data is primarily used for routing. |
+
+| column                 	| type    	| description |
+| ------------------------- | --------- | ----------- |
+| id						| string	| A feature ID. This may be an ID associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
+| geometry					| binary	| The line representation of the segment's location. Segment's geometry which MUST be a LineSting as defined by GeoJSON schema. |
+| bbox						| struct	| Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
+| version					| integer	| Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
+| sources					| struct	| The array of source information for the properties of a given feature, with each entry being a source object which lists the property in JSON Pointer notation and the dataset that specific value came from. All features must have a root level source which is the default source if a specific property's source is not specified. |
+| subtype					| string	| The broad category of transportation segment. |
+| class						| string	| Captures the kind of road and its position in the road network hierarchy. |
+| names						| struct	| Properties defining the names of a feature. |
+| connectors				| struct	| Array of connector IDs identifying the connectors this segment is physically connected to linearly referenced with their location. Each connector is a possible routing decision point, meaning it defines a place along the segment in which there is possibility to transition to other segments which share the same connector. |
+| routes					| struct	| Routes this segment belongs to. |
+| subclass_rules			| struct	| Defines the portion of a road that the subclass applies to. |
+| access_restrictions		| struct	| Rules governing access to this road segment or lane. |
+| level_rules				| struct	| Defines the Z-order, i.e. stacking order, of the road segment. |
+| destinations				| struct	| Describes objects that can be reached by following a transportation segment in the same way those objects are described on signposts or ground writing that a traveller following the segment would observe in the real world. This allows navigation systems to refer to signs and observable writing that a traveller actually sees. |
+| prohibited_transitions	| struct	| Defines where traveling from the segment to another is disallowed for navigation. This covers things situations prohibited turns or a transition from road to bike lane disallowing cars. |
+| road_surface				| struct	| Defines the surface material on a road such as paved, asphalt, or unpaved. |
+| road_flags				| struct	| Additional properties relevant to roads such as is_bridge or is_under_construction. |
+| speed_limits				| struct	| Defines the speed limit of the road segment. |
+| width_rules				| struct	| Defines the width of the road segment for rendering. |
+| subclass					| string	| Specifies the usage of a length of road. |
+| rail_flags				| struct	| Additional properties relevant to rail such as is_tunnel or is_freight. |
+| filename					| string	| Name of the file being queried. |
+| theme						| string	| Name of the Overture theme being queried. |
+| type						| string	| Name of the Overture feature type being queried. |
+
 </TabItem>
 <TabItem value="connector" label="connector" default>
-| column_name | column_type | Description |
-|---|---|---|
-| id | VARCHAR | A feature ID. This may be an ID associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
-| geometry | BLOB | The line representation of the segment's location. Segment's geometry which MUST be a LineSting as defined by GeoJSON schema. |
-| bbox | STRUCT | Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
-| version | INTEGER | Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
-| sources | STRUCT[] | The array of source information for the properties of a given feature, with each entry being a source object which lists the property in JSON Pointer notation and the dataset that specific value came from. All features must have a root level source which is the default source if a specific property's source is not specified. |
+
+| column	| type    	| description |
+| --------- | --------- | ----------- |
+| id		| string	| A feature ID. This may be an ID associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
+| geometry	| binary	| The line representation of the segment's location. Segment's geometry which MUST be a LineSting as defined by GeoJSON schema. |
+| bbox		| struct	| Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
+| version	| integer	| Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
+| sources	| struct	| The array of source information for the properties of a given feature, with each entry being a source object which lists the property in JSON Pointer notation and the dataset that specific value came from. All features must have a root level source which is the default source if a specific property's source is not specified. |
+| filename	| string	| Name of the file being queried. |
+| theme		| string	| Name of the Overture theme being queried. |
+| type		| string	| Name of the Overture feature type being queried. |
+
 </TabItem>
 </Tabs>
 </div>

--- a/docs/guides/transportation.mdx
+++ b/docs/guides/transportation.mdx
@@ -44,7 +44,7 @@ All Overture data, including transportation data, is distributed as GeoParquet, 
 <TabItem value="segment" label="segment" default>
 
 | column | type | description |
-| --- | --- | --- | --- |
+| --- | --- | --- |
 | id | string | A feature ID. This may be an ID associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
 | geometry | binary | The line representation of the segment's location. Segment's geometry which MUST be a LineSting as defined by GeoJSON schema. |
 | bbox | struct | Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
@@ -74,7 +74,7 @@ All Overture data, including transportation data, is distributed as GeoParquet, 
 <TabItem value="connector" label="connector" default>
 
 | column | type | description |
-| --- | --- | --- | --- |
+| --- | --- | --- |
 | id | string | A feature ID. This may be an ID associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
 | geometry | binary | The line representation of the segment's location. Segment's geometry which MUST be a LineSting as defined by GeoJSON schema. |
 | bbox | struct | Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |

--- a/docs/guides/transportation.mdx
+++ b/docs/guides/transportation.mdx
@@ -43,46 +43,46 @@ All Overture data, including transportation data, is distributed as GeoParquet, 
 <Tabs>
 <TabItem value="segment" label="segment" default>
 
-| column                 	| type    	| description |
-| ------------------------- | --------- | ----------- |
-| id						| string	| A feature ID. This may be an ID associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
-| geometry					| binary	| The line representation of the segment's location. Segment's geometry which MUST be a LineSting as defined by GeoJSON schema. |
-| bbox						| struct	| Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
-| version					| integer	| Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
-| sources					| struct	| The array of source information for the properties of a given feature, with each entry being a source object which lists the property in JSON Pointer notation and the dataset that specific value came from. All features must have a root level source which is the default source if a specific property's source is not specified. |
-| subtype					| string	| The broad category of transportation segment. |
-| class						| string	| Captures the kind of road and its position in the road network hierarchy. |
-| names						| struct	| Properties defining the names of a feature. |
-| connectors				| struct	| Array of connector IDs identifying the connectors this segment is physically connected to linearly referenced with their location. Each connector is a possible routing decision point, meaning it defines a place along the segment in which there is possibility to transition to other segments which share the same connector. |
-| routes					| struct	| Routes this segment belongs to. |
-| subclass_rules			| struct	| Defines the portion of a road that the subclass applies to. |
-| access_restrictions		| struct	| Rules governing access to this road segment or lane. |
-| level_rules				| struct	| Defines the Z-order, i.e. stacking order, of the road segment. |
-| destinations				| struct	| Describes objects that can be reached by following a transportation segment in the same way those objects are described on signposts or ground writing that a traveller following the segment would observe in the real world. This allows navigation systems to refer to signs and observable writing that a traveller actually sees. |
-| prohibited_transitions	| struct	| Defines where traveling from the segment to another is disallowed for navigation. This covers things situations prohibited turns or a transition from road to bike lane disallowing cars. |
-| road_surface				| struct	| Defines the surface material on a road such as paved, asphalt, or unpaved. |
-| road_flags				| struct	| Additional properties relevant to roads such as is_bridge or is_under_construction. |
-| speed_limits				| struct	| Defines the speed limit of the road segment. |
-| width_rules				| struct	| Defines the width of the road segment for rendering. |
-| subclass					| string	| Specifies the usage of a length of road. |
-| rail_flags				| struct	| Additional properties relevant to rail such as is_tunnel or is_freight. |
-| filename					| string	| Name of the file being queried. |
-| theme						| string	| Name of the Overture theme being queried. |
-| type						| string	| Name of the Overture feature type being queried. |
+| column | type | description |
+| --- | --- | --- | --- |
+| id | string | A feature ID. This may be an ID associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
+| geometry | binary | The line representation of the segment's location. Segment's geometry which MUST be a LineSting as defined by GeoJSON schema. |
+| bbox | struct | Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
+| version | integer | Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
+| sources | struct | The array of source information for the properties of a given feature, with each entry being a source object which lists the property in JSON Pointer notation and the dataset that specific value came from. All features must have a root level source which is the default source if a specific property's source is not specified. |
+| subtype | string | The broad category of transportation segment. |
+| class | string | Captures the kind of road and its position in the road network hierarchy. |
+| names | struct | Properties defining the names of a feature. |
+| connectors | struct | Array of connector IDs identifying the connectors this segment is physically connected to linearly referenced with their location. Each connector is a possible routing decision point, meaning it defines a place along the segment in which there is possibility to transition to other segments which share the same connector. |
+| routes | struct | Routes this segment belongs to. |
+| subclass_rules | struct | Defines the portion of a road that the subclass applies to. |
+| access_restrictions | struct | Rules governing access to this road segment or lane. |
+| level_rules | struct | Defines the Z-order, i.e. stacking order, of the road segment. |
+| destinations | struct | Describes objects that can be reached by following a transportation segment in the same way those objects are described on signposts or ground writing that a traveller following the segment would observe in the real world. This allows navigation systems to refer to signs and observable writing that a traveller actually sees. |
+| prohibited_transitions | struct | Defines where traveling from the segment to another is disallowed for navigation. This covers things situations prohibited turns or a transition from road to bike lane disallowing cars. |
+| road_surface | struct | Defines the surface material on a road such as paved, asphalt, or unpaved. |
+| road_flags | struct | Additional properties relevant to roads such as is_bridge or is_under_construction. |
+| speed_limits | struct | Defines the speed limit of the road segment. |
+| width_rules | struct | Defines the width of the road segment for rendering. |
+| subclass | string | Specifies the usage of a length of road. |
+| rail_flags | struct | Additional properties relevant to rail such as is_tunnel or is_freight. |
+| filename | string | Name of the file being queried. |
+| theme | string | Name of the Overture theme being queried. |
+| type | string | Name of the Overture feature type being queried. |
 
 </TabItem>
 <TabItem value="connector" label="connector" default>
 
-| column	| type    	| description |
-| --------- | --------- | ----------- |
-| id		| string	| A feature ID. This may be an ID associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
-| geometry	| binary	| The line representation of the segment's location. Segment's geometry which MUST be a LineSting as defined by GeoJSON schema. |
-| bbox		| struct	| Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
-| version	| integer	| Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
-| sources	| struct	| The array of source information for the properties of a given feature, with each entry being a source object which lists the property in JSON Pointer notation and the dataset that specific value came from. All features must have a root level source which is the default source if a specific property's source is not specified. |
-| filename	| string	| Name of the file being queried. |
-| theme		| string	| Name of the Overture theme being queried. |
-| type		| string	| Name of the Overture feature type being queried. |
+| column | type | description |
+| --- | --- | --- | --- |
+| id | string | A feature ID. This may be an ID associated with the Global Entity Reference System (GERS) if—and-only-if the feature represents an entity that is part of GERS. |
+| geometry | binary | The line representation of the segment's location. Segment's geometry which MUST be a LineSting as defined by GeoJSON schema. |
+| bbox | struct | Area defined by two longitudes and two latitudes: latitude is a decimal number between -90.0 and 90.0; longitude is a decimal number between -180.0 and 180.0. |
+| version | integer | Version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed. |
+| sources | struct | The array of source information for the properties of a given feature, with each entry being a source object which lists the property in JSON Pointer notation and the dataset that specific value came from. All features must have a root level source which is the default source if a specific property's source is not specified. |
+| filename | string | Name of the file being queried. |
+| theme | string | Name of the Overture theme being queried. |
+| type | string | Name of the Overture feature type being queried. |
 
 </TabItem>
 </Tabs>
@@ -97,45 +97,45 @@ Transportation segments are divided into three subtypes: **rail**, **water**, an
 <div>
 <Tabs>
 <TabItem value="classes" label="classes" default>
-| subtype | class | subclass | Feature count, June 2025 release |
-|---|---|---|---|
-| rail    | funicular      |                |       1,297 |
-| rail    | light_rail     |                |      15,930 |
-| rail    | monorail       |                |       2,979 |
-| rail    | narrow_gauge   |                |      30,843 |
-| rail    | standard_gauge |                |   1,423,890 |
-| rail    | subway         |                |      52,344 |
-| rail    | tram           |                |      59,142 |
-| rail    | unknown        |                |     372,866 |
-| road    | bridleway      |                |      99,049 |
-| road    | cycleway       | cycle_crossing |      55,477 |
-| road    | cycleway       |                |   1,259,399 |
-| road    | footway        | crosswalk      |   2,109,280 |
-| road    | footway        | sidewalk       |   3,394,404 |
-| road    | footway        |                |  15,631,725 |
-| road    | living_street  |                |   3,296,747 |
-| road    | motorway       | link           |     638,701 |
-| road    | motorway       |                |     432,035 |
-| road    | path           |                |  13,329,876 |
-| road    | pedestrian     |                |     461,593 |
-| road    | primary        | link           |     487,257 |
-| road    | primary        |                |   6,670,265 |
-| road    | residential    |                | 125,385,316 |
-| road    | secondary      | link           |     385,637 |
-| road    | secondary      |                |  10,666,584 |
-| road    | service        | alley          |   1,664,772 |
-| road    | service        | driveway       |  16,377,919 |
-| road    | service        | parking_aisle  |   6,266,426 |
-| road    | service        |                |  32,743,206 |
-| road    | steps          |                |   1,836,112 |
-| road    | tertiary       | link           |     295,551 |
-| road    | tertiary       |                |  19,711,085 |
-| road    | track          |                |  25,012,146 |
-| road    | trunk          | link           |     547,842 |
-| road    | trunk          |                |   3,417,014 |
-| road    | unclassified   |                |  29,488,205 |
-| road    | unknown        |                |     704,794 |
-| water   |                |                |      28,224 |
+| subtype | class | subclass | feature count, June 2025 |
+| --- | --- | --- | --- |
+| rail | funicular |  | 1,297 |
+| rail | light_rail |  | 15,930 |
+| rail | monorail |  | 2,979 |
+| rail | narrow_gauge |  | 30,843 |
+| rail | standard_gauge |  | 1,423,890 |
+| rail | subway |  | 52,344 |
+| rail | tram |  | 59,142 |
+| rail | unknown |  | 372,866 |
+| road | bridleway |  | 99,049 |
+| road | cycleway | cycle_crossing | 55,477 |
+| road | cycleway |  | 1,259,399 |
+| road | footway | crosswalk | 2,109,280 |
+| road | footway | sidewalk | 3,394,404 |
+| road | footway |  | 15,631,725 |
+| road | living_street |  | 3,296,747 |
+| road | motorway | link | 638,701 |
+| road | motorway |  | 432,035 |
+| road | path |  | 13,329,876 |
+| road | pedestrian |  | 461,593 |
+| road | primary | link | 487,257 |
+| road | primary |  | 6,670,265 |
+| road | residential |  | 125,385,316 |
+| road | secondary | link | 385,637 |
+| road | secondary |  | 10,666,584 |
+| road | service | alley | 1,664,772 |
+| road | service | driveway | 16,377,919 |
+| road | service | parking_aisle | 6,266,426 |
+| road | service |  | 32,743,206 |
+| road | steps |  | 1,836,112 |
+| road | tertiary | link | 295,551 |
+| road | tertiary |  | 19,711,085 |
+| road | track |  | 25,012,146 |
+| road | trunk | link | 547,842 |
+| road | trunk |  | 3,417,014 |
+| road | unclassified |  | 29,488,205 |
+| road | unknown |  | 704,794 |
+| water |  |  | 28,224 |
 
 </TabItem>
 </Tabs>
@@ -148,14 +148,14 @@ Overture's transportation theme data is freely available on both Amazon S3 and M
 
 <Tabs>
 <TabItem value="segment_url" label="Segment" default>
-| Provider | Location |
-| ------ | -------- |
+| provider | location |
+| --- | --- |
 | Amazon S3 | <QueryBuilder query="s3://overturemaps-us-west-2/release/__OVERTURE_RELEASE/theme=transportation/type=segment/*" language="text"></QueryBuilder>|
 | Azure Blob Storage | <QueryBuilder query="https://overturemapswestus2.blob.core.windows.net/release/__OVERTURE_RELEASE/theme=transportation/type=segment/*" language="text"></QueryBuilder> |
 </TabItem>
 <TabItem value="connector_url" label="Connector" default>
-| Provider | Location |
-| ------ | -------- |
+| provider | location |
+| --- | --- |
 | Amazon S3 | <QueryBuilder query="s3://overturemaps-us-west-2/release/__OVERTURE_RELEASE/theme=transportation/type=connector/*" language="text"></QueryBuilder>|
 | Azure Blob Storage | <QueryBuilder query="https://overturemapswestus2.blob.core.windows.net/release/__OVERTURE_RELEASE/theme=transportation/type=connector/*" language="text"></QueryBuilder> |
 </TabItem>


### PR DESCRIPTION
## Pull Request

Changes include:

- New/updated "Understanding the parquet files" tables for each of the themes, with standardized formatting and descriptions. All types are now included.
- Various formatting fixes/improvements
- New `roof_height` property/description on the buildings theme guide
- New `destinations` property/description on the transportation theme guide

### Docs Preview:

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/how-to/pr/208)

View all staged runs:
https://github.com/OvertureMaps/docs/actions/workflows/publish-pr-to-staging.yml
