### PR TITLE
add data retention policy to releases page

### DIFF
--- a/docs/release-calendar.mdx
+++ b/docs/release-calendar.mdx
@@ -1,39 +1,60 @@
 ---
-title: Release Calendar
+title: Releases
 ---
 
-## Versioning 
-Overture uses a three-component `<major>.<minor>.<patch>` version number, i.e. `v1.1.0`, that effectively follows the [semantic versioning specification](https://semver.org/spec/v2.0.0.html). In general, a “major” change is expected to have a larger impact on data consumers, while a “minor” change is expected to have a lesser impact. Our monthly data releases are tagged with the date of the release, in the format `yyyy-mm-dd.x`, with x indicating a patch or hotfix to the data. 
+This page provides information about Overture's data and schema releases, including upcoming release dates, our versioning and schema change policies, data retention practices, and a complete history of past releases with links to release notes.
 
-## Upcoming releases
+## Release schedule
 
-Our planned release schedule for the next two months is below. The release dates and schema versions are tentative.
+Our planned release schedule for the next two months is below. The release dates and schema versions are subject to change.
 
 | Date | Data version | Schema version |
 | ----- | ----- | ----- |
-| 20 August 2025 | [`2025-08-20.0`](https://docs.overturemaps.org/blog/2025/08/20/release-notes/) | [`v1.11.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.11.0) |
-| 24 September 2025 | `2025-09-24` | ? |
+| 24 September 2025 | `2025-09-24.0` | `v1.12.0` |
+| 22 October 2025 | `2025-10-22.0` | `v1.13.0` | 
 
 
-## Past releases
+## Versioning and schema changes
+
+Overture uses a three-component `<major>.<minor>.<patch>` version number, i.e. `v1.1.0`, that effectively follows the [semantic versioning specification](https://semver.org/spec/v2.0.0.html). In general, a “major” change is expected to have a larger impact on data consumers, while a “minor” change is expected to have a lesser impact. Our monthly data releases are tagged with the date of the release, in the format `yyyy-mm-dd.x`, with x indicating a patch or hotfix to the data. 
+
+Minor schema changes may occur in any month, meaning that the next monthly data release may follow a new schema version that contains minor schema changes. We typically do not announce minor changes in advance unless they are part of an overarching schema update that involves related major changes. Minor changes include: 
+- adding feature types; 
+- adding top-level properties (columns); 
+- adding nested properties; 
+- changing constraints on property values either by relaxing or tightening them, e.g. adding or subtracting allowed values for enumerated value properties such as `class`. 
+
+Major schema changes will only occur once per quarter, during the designated **major change months of March, June, September, and December**. We will strive to announce upcoming major changes as far in advance as possible, along with the reasons behind the change. If there are no major changes in a designated major change month, the schema version for that month’s release will reflect minor changes or no changes. Major changes include: 
+- deleting feature types;
+- deleting top-level properties (columns); 
+- deleting nested properties;
+- changing data types, e.g. an integer value to a structured object. 
+
+## Data retention policy
+
+Overture maintains publicly available data releases for a maximum of 60 days (two monthly releases) to comply with data protection regulations, including GDPR "right to be forgotten" requirements. Files are automatically removed from public distribution after this period using cloud storage lifecycle policies on AWS and Azure. Versioned changelogs and bridgefiles remain publicly available for all releases where they were provided. Release notes from past releases also remain publicly available.
+
+
+## Release history
 
 Overture has been releasing data monthly since October 2023. The data releases and their corresponding schema versions are listed below, with links to the release notes. 
 
 | Date | Data version | Schema version |
 | ----- | ----- | ----- |
+| 20 August 2025 | [`2025-08-20.0`](https://docs.overturemaps.org/blog/2025/08/20/release-notes/) | [`v1.11.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.11.0) |
 | 23 July 2025 | [`2025-07-23.0`](https://docs.overturemaps.org/blog/2025/07/23/release-notes/) | [`v1.11.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.11.0) | 
 | 25 June 2025	| [`2025-06-25.0`](https://docs.overturemaps.org/blog/2025/06/25/release-notes/) | [`v1.10.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.10.0)| 
-| 21 May 2025	| [`2025-05-21.0`](https://docs.overturemaps.org/blog/2025/05/21/release-notes/) | [`v.1.9.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.9.0) | 
-| 23 April 2025 | [`2025-04-23.0`](https://docs.overturemaps.org/blog/2025/04/23/release-notes/) | [`v.1.8.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.8.0) | 
-| 20 March 2025 | [`2025-03-19.1`](https://docs.overturemaps.org/blog/2025/03/19/release-notes/) | [`v.1.7.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.7.0) |
-| 19 March 2025 | [`2025-03-19.0`](https://docs.overturemaps.org/blog/2025/03/19/release-notes/) | [`v.1.7.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.7.0) |
-| 19 February 2025 | [`2025-02-19.0`](https://docs.overturemaps.org/blog/2025/02/19/release-notes/) | [`v.1.6.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.6.0) | 
-| 22 January 2025 | [`2025-01-22.0`](https://docs.overturemaps.org/blog/2025/01/22/release-notes/)| [`v.1.5.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.5.0) | 
-| 18 December 2024 | [`2024-12-18.0`](https://docs.overturemaps.org/blog/2024-12-18.0/) | [`v.1.4.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.4.0) |
-| 13 November 2024	| [`2024-11-13.0`](https://docs.overturemaps.org/blog/2024-11-13.0/) | [`v.1.3.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.3.0) | 
-| 23 October 2024 | [`2024-10-23.0`](https://docs.overturemaps.org/blog/2024-10-23.0/) | [`v.1.2.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.2.0) | 
-| 18 September 2024 | [`2024-09-18.0`](https://docs.overturemaps.org/blog/2024-09-18.0/) | [`v.1.1.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.1.0) |
-| 20 August 2024	| [`2024-08-20.0`](https://docs.overturemaps.org/blog/2024-08-20.0/) | [`v.1.1.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.1.0) | 
+| 21 May 2025	| [`2025-05-21.0`](https://docs.overturemaps.org/blog/2025/05/21/release-notes/) | [`v1.9.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.9.0) | 
+| 23 April 2025 | [`2025-04-23.0`](https://docs.overturemaps.org/blog/2025/04/23/release-notes/) | [`v1.8.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.8.0) | 
+| 20 March 2025 | [`2025-03-19.1`](https://docs.overturemaps.org/blog/2025/03/19/release-notes/) | [`v1.7.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.7.0) |
+| 19 March 2025 | [`2025-03-19.0`](https://docs.overturemaps.org/blog/2025/03/19/release-notes/) | [`v1.7.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.7.0) |
+| 19 February 2025 | [`2025-02-19.0`](https://docs.overturemaps.org/blog/2025/02/19/release-notes/) | [`v1.6.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.6.0) | 
+| 22 January 2025 | [`2025-01-22.0`](https://docs.overturemaps.org/blog/2025/01/22/release-notes/)| [`v1.5.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.5.0) | 
+| 18 December 2024 | [`2024-12-18.0`](https://docs.overturemaps.org/blog/2024-12-18.0/) | [`v1.4.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.4.0) |
+| 13 November 2024	| [`2024-11-13.0`](https://docs.overturemaps.org/blog/2024-11-13.0/) | [`v1.3.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.3.0) | 
+| 23 October 2024 | [`2024-10-23.0`](https://docs.overturemaps.org/blog/2024-10-23.0/) | [`v1.2.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.2.0) | 
+| 18 September 2024 | [`2024-09-18.0`](https://docs.overturemaps.org/blog/2024-09-18.0/) | [`v1.1.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.1.0) |
+| 20 August 2024	| [`2024-08-20.0`](https://docs.overturemaps.org/blog/2024-08-20.0/) | [`v1.1.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.1.0) | 
 | 22 July 2024 | [`2024-07-22.0`](https://docs.overturemaps.org/blog/2024-07-22.0/) | [`v1.0.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.0.0) | 
 | 24 June 2024 | `2024-06-13-beta.1` | `v0.12.0-beta` |
 | 13 June 2024 | `2024-06-13-beta.0` | `v0.12.0-beta` |


### PR DESCRIPTION
## What's in this PR?
- text about data retention policy on the releases page
- reorganization of releases page
- link updates

### Docs Preview:
Click the most recent "View Deployment"

[All Staging Deployments](https://github.com/OvertureMaps/docs/actions/workflows/staging_deploy_documentation.yml)
