### PR TITLE
Remove 'borough', 'macroregion', and 'macrocountry' from the subtype table

### DIFF
--- a/docs/guides/divisions.mdx
+++ b/docs/guides/divisions.mdx
@@ -58,13 +58,10 @@ Subtypes can represent each feature's administrative level, from `country` down 
 | --- | --- | --- |
 | **country** | Largest unit of independent sovereignty. | United States |
 | **dependency** | A place that is not exactly a sub-region of a country but is dependent on a parent company for defence, passport control, subsidies, etc. | Puerto Rico |
-| **macroregion** | A bundle of regions. These exist mainly in Europe. | Scotland; Île-de-France |
 | **region** | States, provinces, regions. Largest sub-country administrative unit most countries, unless they have dependencies/macroregions. | Alaska; Alberta |
-| **macrocounty** | A bundle of counties. Again, these exist mainly in Europe. | Inverness |
 | **county** | Counties... Largest sub-region administrative unit in most countries, unless they have macrocounties. | Kings County, NY |
 | **localadmin** | A level of government available in some parts of the world that contains localities or populated places that themselves have no authority. Often but not exclusively found in Europe. | Paris |
 | **locality** | A populated place that may or may not have its own administrative authority. (It won't if it belongs to a localadmin.) | Taipei |
-| **borough** | A local government unit, below the locality placetype. | Brooklyn, Queens, etc. |
 | **macrohood** | A super-neighborhood that contains smaller divisions of type neighborhood. | BoCoCa (Boerum Hill, Cobble Hill, and Carroll Gardens) |
 | **neighborhood** | A neighborhood. Most neighborhoods will be just this, unless there's enough granular division to warrant introducing macrohood and/or microhood divisions. | Cobble Hill |
 | **microhood** | A mini-neighborhood that is contained within a division of type neighborhood. | Gätjensort in Hamburg |

--- a/docs/release-calendar.mdx
+++ b/docs/release-calendar.mdx
@@ -6,7 +6,7 @@ This page provides information about Overture's data and schema releases, includ
 
 ## Current release
 
-The latest Overture data release is `2025-09-24.0`. The schema version is `v1.12.0`. The release notes with the full data access paths are available [here](https://docs.overturemaps.org/blog/2025/09/24/release-notes/). 
+The latest Overture data release is `2025-10-22.0`. The schema version is `v1.13.0`. See the [release notes](https://docs.overturemaps.org/blog/2025/10/22/release-notes/) for the full data access paths and more.
 
 ## Release schedule
 
@@ -14,9 +14,8 @@ Our planned release schedule for the next two months is below. The release dates
 
 | Date | Data version | Schema version |
 | ----- | ----- | ----- |
-| 22 October 2025 | `2025-10-22.0` | `v1.13.0` | 
-| 19 November 2025 | `2025-11-19.0` | `v1.14.0` | 
-
+| 19 November 2025 | `2025-11-19.0` | `v1.14.0` |
+| TBA | `2025-12-XX.0` | `v1.1X.0` |
 
 ## Versioning and schema changes
 
@@ -51,6 +50,7 @@ Overture has been releasing data monthly since October 2023. Past releases are l
 
 | Date | Data version | Schema version |
 | ----- | ----- | ----- |
+| 22 October 2025 | [`2025-10-22.0`](https://docs.overturemaps.org/blog/2025/10/22/release-notes/) | [`v1.13.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.13.0) |
 | 24 September 2025 | [`2025-09-24.0`](https://docs.overturemaps.org/blog/2025/09/24/release-notes/) | [`v1.12.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.12.0) |
 | 20 August 2025 | [`2025-08-20.0`](https://docs.overturemaps.org/blog/2025/08/20/release-notes/) | [`v1.11.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.11.0) |
 | 23 July 2025 | [`2025-07-23.0`](https://docs.overturemaps.org/blog/2025/07/23/release-notes/) | [`v1.11.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.11.0) | 


### PR DESCRIPTION
Please ignore if I mistakenly removed these values, but they seem to (no longer) be valid values.

Confirmed with:

```sql
INSTALL httpfs;
LOAD httpfs;
SET s3_region='us-west-2';

SELECT DISTINCT subtype FROM read_parquet('s3://overturemaps-us-west-2/release/2025-10-22.0/theme=divisions/type=division/*.parquet') WHERE 
    subtype IS NOT NULL ORDER BY subtype;
```

result:

<img width="189" height="335" alt="image" src="https://github.com/user-attachments/assets/3b30781f-6c95-41b3-88d9-0d732b981b6c" />


## Pull Request

### Docs Preview:
Click the most recent "View Deployment"

[All Staging Deployments](https://github.com/OvertureMaps/docs/actions/workflows/staging_deploy_documentation.yml)
