### PR TITLE
[TASK] Define CODEOWNERS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+---
+version: 2
+updates:
+
+  # Maintain GitHub Actions dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "bot"
+    commit-message:
+      prefix: "[CHORE](deps)"
+      include: "scope"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for everything in the repo
+* @overturemaps/omf-public-reviewers


### PR DESCRIPTION
* Add .github/dependabot.yml to enable weekly Dependabot updates for GitHub Actions (limit 5 open PRs, apply "bot" label, and use commit prefix "[CHORE](deps)"). 

* Add CODEOWNERS to set @overturemaps/omf-public-reviewers as the default owner for the repository. 

Partially resolves https://github.com/OvertureMaps/ops-team/issues/274