### PR TITLE
Fix nesting and ordering for annotated union fields

### DIFF
--- a/src/components/SmartTable.jsx
+++ b/src/components/SmartTable.jsx
@@ -168,6 +168,7 @@ function TableGroup({ group, isExpanded, onToggle, searchTerm, level = 0, expand
       <tr className={level > 0 ? `nested-field nested-level-${level}` : ''}>
         <td>
           <code>{highlightText(group.name, searchTerm)}</code>
+          {group.annotation && <em> ({group.annotation})</em>}
         </td>
         <td>{renderRichContent(group.type, searchTerm)}</td>
         <td>{renderRichContent(group.description, searchTerm)}</td>
@@ -194,6 +195,7 @@ function TableGroup({ group, isExpanded, onToggle, searchTerm, level = 0, expand
             </span>
           </button>
           <code>{highlightText(group.name, searchTerm)}</code>
+          {group.annotation && <em> ({group.annotation})</em>}
           {group.children.length > 0 && (
             <span className="child-count" aria-label={`${getTotalChildCount(group)} child fields`}>
               ({getTotalChildCount(group)})
@@ -222,11 +224,16 @@ function TableGroup({ group, isExpanded, onToggle, searchTerm, level = 0, expand
 
 // Auto-detect field groupings based on common prefixes with recursive nesting
 function autoDetectFieldGroups(rows) {
-  const fields = rows.map((row) => ({
-    name: extractFieldName(row[0]), // Extract from first column
-    type: row[1],
-    description: row[2],
-  }));
+  const fields = rows.map((row, index) => {
+    const { name, annotation } = extractFieldName(row[0]);
+    return {
+      name,
+      annotation,
+      type: row[1],
+      description: row[2],
+      originalIndex: index,
+    };
+  });
 
   return buildNestedGroups(fields);
 }
@@ -264,25 +271,32 @@ function buildNestedGroups(fields) {
 
       groups.push({
         name: field.name,
+        annotation: field.annotation,
         type: field.type,
         description: field.description,
         isCollapsible: true,
         children: nestedChildren,
         level: getFieldLevel(field.name),
+        originalIndex: field.originalIndex,
       });
     } else {
       // Standalone field
       groups.push({
         name: field.name,
+        annotation: field.annotation,
         type: field.type,
         description: field.description,
         isCollapsible: false,
         children: [],
         level: getFieldLevel(field.name),
+        originalIndex: field.originalIndex,
       });
     }
     processed.add(field.name);
   }
+
+  // Restore original source order from the markdown
+  groups.sort((a, b) => a.originalIndex - b.originalIndex);
 
   return groups;
 }
@@ -491,11 +505,13 @@ function highlightText(text, searchTerm) {
 }
 
 function extractFieldName(cellContent) {
-  // Extract field name from cell content (remove code formatting, etc.)
-  if (typeof cellContent === 'string') {
-    return cellContent.trim();
+  // Extract field name, separating trailing annotations like (Road)/(Rail)
+  const raw = typeof cellContent === 'string' ? cellContent.trim() : String(cellContent || '').trim();
+  const match = raw.match(/^(.+?)\s*\(([^)]+)\)\s*$/);
+  if (match) {
+    return { name: match[1], annotation: match[2] };
   }
-  return String(cellContent || '').trim();
+  return { name: raw, annotation: null };
 }
 
 function isSchemaTable(headers) {


### PR DESCRIPTION
## Summary

- Fix SmartTable collapsing for fields with subtype annotations like `destinations[] (Road)` and `prohibited_transitions[] (Road)`
- Preserve original markdown source order instead of alphabetical sorting
- Render annotations as `<em>` outside `<code>` elements

MDX's table cell parser absorbs emphasis markers into the preceding code span, so `` `destinations[]` *(Road)* `` produces `<code>destinations[] (Road)</code>` as a single element. This caused `isDescendant()` to fail because the parent name `"destinations[] (Road)"` didn't match the `"destinations[]."` prefix of child field names.

`extractFieldName` now strips trailing parenthetical annotations and returns them separately for rendering.

This fixes the issue that @RoelBollens-TomTom flagged where some fields weren't nesting properly.

## Test plan

- [x] Verify `destinations[]` on the [segment page](/schema/reference/transportation/segment) shows as collapsible with child fields nested underneath
- [x] Verify `prohibited_transitions[]`, `road_flags[]`, `road_surface[]`, `speed_limits[]`, `width_rules[]`, `rail_flags[]` all collapse correctly
- [x] Verify field order matches the markdown source (not alphabetical)
- [x] Verify annotations like *(Road)* and *(Rail)* render as italicized text outside the code span
- [x] Verify non-annotated collapsible fields (`sources[]`, `names`, `routes[]`, etc.) still work