### PR TITLE
[BUG](mobile) pin nav links in mobile sidebar secondary menu

### DIFF
--- a/src/theme/Navbar/MobileSidebar/SecondaryMenu/index.js
+++ b/src/theme/Navbar/MobileSidebar/SecondaryMenu/index.js
@@ -3,12 +3,12 @@
  *
  * The secondary menu is what users see when they tap the hamburger button
  * while on a docs page — it defaults to showing the docs sidebar. The
- * top-level navbar links (Blog, Community) are hidden behind a
- * "Back to main menu" button, making them impossible to discover on mobile.
+ * top-level navbar links (Blog, Community) were not visible at all, making
+ * them impossible to discover on mobile.
  *
  * This override pins the labeled navbar items at the top of the secondary
- * menu so that Blog and Community are immediately visible without an extra
- * navigation step.
+ * menu so that Blog and Community are immediately visible. The "Back to main
+ * menu" button is removed since all labeled nav items are now shown inline.
  */
 import React from 'react';
 import {useThemeConfig} from '@docusaurus/theme-common';
@@ -16,26 +16,12 @@ import {
   useNavbarMobileSidebar,
   useNavbarSecondaryMenu,
 } from '@docusaurus/theme-common/internal';
-import Translate from '@docusaurus/Translate';
 import NavbarItem from '@theme/NavbarItem';
-
-function SecondaryMenuBackButton(props) {
-  return (
-    <button {...props} type="button" className="clean-btn navbar-sidebar__back">
-      <Translate
-        id="theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel"
-        description="The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)">
-        ← Back to main menu
-      </Translate>
-    </button>
-  );
-}
 
 export default function NavbarMobileSidebarSecondaryMenu() {
   const {
     navbar: {items},
   } = useThemeConfig();
-  const isPrimaryMenuEmpty = items.length === 0;
   const secondaryMenu = useNavbarSecondaryMenu();
   const mobileSidebar = useNavbarMobileSidebar();
 
@@ -55,10 +41,6 @@ export default function NavbarMobileSidebarSecondaryMenu() {
             />
           ))}
         </ul>
-      )}
-      {/* Back button lets users reach any remaining items (e.g. GitHub icon) */}
-      {!isPrimaryMenuEmpty && (
-        <SecondaryMenuBackButton onClick={() => secondaryMenu.hide()} />
       )}
       {secondaryMenu.content}
     </>

--- a/src/theme/Navbar/MobileSidebar/SecondaryMenu/index.js
+++ b/src/theme/Navbar/MobileSidebar/SecondaryMenu/index.js
@@ -1,0 +1,66 @@
+/**
+ * Swizzle of Navbar/MobileSidebar/SecondaryMenu.
+ *
+ * The secondary menu is what users see when they tap the hamburger button
+ * while on a docs page — it defaults to showing the docs sidebar. The
+ * top-level navbar links (Blog, Community) are hidden behind a
+ * "Back to main menu" button, making them impossible to discover on mobile.
+ *
+ * This override pins the labeled navbar items at the top of the secondary
+ * menu so that Blog and Community are immediately visible without an extra
+ * navigation step.
+ */
+import React from 'react';
+import {useThemeConfig} from '@docusaurus/theme-common';
+import {
+  useNavbarMobileSidebar,
+  useNavbarSecondaryMenu,
+} from '@docusaurus/theme-common/internal';
+import Translate from '@docusaurus/Translate';
+import NavbarItem from '@theme/NavbarItem';
+
+function SecondaryMenuBackButton(props) {
+  return (
+    <button {...props} type="button" className="clean-btn navbar-sidebar__back">
+      <Translate
+        id="theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel"
+        description="The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)">
+        ← Back to main menu
+      </Translate>
+    </button>
+  );
+}
+
+export default function NavbarMobileSidebarSecondaryMenu() {
+  const {
+    navbar: {items},
+  } = useThemeConfig();
+  const isPrimaryMenuEmpty = items.length === 0;
+  const secondaryMenu = useNavbarSecondaryMenu();
+  const mobileSidebar = useNavbarMobileSidebar();
+
+  // Exclude icon-only items (e.g. GitHub link) that have no visible label.
+  const labeledItems = items.filter((item) => item.label);
+
+  return (
+    <>
+      {labeledItems.length > 0 && (
+        <ul className="menu__list">
+          {labeledItems.map((item, i) => (
+            <NavbarItem
+              key={i}
+              mobile
+              {...item}
+              onClick={() => mobileSidebar.toggle()}
+            />
+          ))}
+        </ul>
+      )}
+      {/* Back button lets users reach any remaining items (e.g. GitHub icon) */}
+      {!isPrimaryMenuEmpty && (
+        <SecondaryMenuBackButton onClick={() => secondaryMenu.hide()} />
+      )}
+      {secondaryMenu.content}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Fixes #365

- On mobile, tapping the hamburger while on a docs page opens the docs sidebar (secondary menu) by default
- **Docs**, **Blog**, and **Community** links were only reachable by tapping "← Back to main menu" — completely non-obvious
- Swizzles `Navbar/MobileSidebar/SecondaryMenu` to render the labeled navbar items at the top of the secondary menu, so cross-section navigation is immediately visible

## Visual Tests

### Before

It is extremely hard to find the pages, even if you know they exist, on mobile view:

1. Click hamburger menu
2. Click "Back to Main Menu"
3. Click "Community" or "Blog" to access either

<img width="749" height="421" alt="{BE5A3F9B-5305-417A-9F36-E705944C9F96}" src="https://github.com/user-attachments/assets/5b2114ef-d448-40b9-8007-efa2f1e18db9" />

<img width="755" height="407" alt="{99E05648-E6D6-40AE-95A9-9BEE86594A1D}" src="https://github.com/user-attachments/assets/91070285-a309-4e54-98e2-fbb5235e5ff1" />


### After

Users will always see the Blog and Community pages in the hamburger menu.

<img width="400" height="310" alt="{75177B80-2D60-4C3A-BFFA-01F8167B2687}" src="https://github.com/user-attachments/assets/5cf6f98a-ecc0-4141-9677-6331dbea881a" />



<img width="760" height="433" alt="{E7772A75-569E-45D3-BFBA-3A72DF778275}" src="https://github.com/user-attachments/assets/5008a943-6d67-4a40-b34d-d02112efda1b" />
