### PR TITLE
[DOCS] Update transportation stats, osm date for April

### DIFF
--- a/blog/2026-04-15-release-notes.mdx
+++ b/blog/2026-04-15-release-notes.mdx
@@ -112,18 +112,18 @@ The base, buildings, divisions, places, and transportation themes are in GA. The
 
 ### Transportation
 
-- OSM Cut-Off Date: 2026-03-31
+- OSM Cut-Off Date: `2026-04-04`
 
 | Dataset | Feature Count | Length (km) |
 |---|---|---|
-| OpenStreetMap | 744,477,991 | 93,712,547 |
-| TomTom | 8,776,616 | 1,528,190 |
+| OpenStreetMap | 745,146,752 | 93,767,467 |
+| TomTom | 8,758,473 | 1,528,165 |
 
 | Subtype | Length (km) |
 |---|---|
-| road | 91,800,093 |
-| rail | 2,859,209 |
-| water | 581,435 |
+| road | 91,854,341 |
+| rail | 2,859,987 |
+| water | 581,304 |
 
 #### Change Summary
 
@@ -131,17 +131,17 @@ The base, buildings, divisions, places, and transportation themes are in GA. The
 
 | Dataset | Type | Diff | Diff (%) |
 |---|---|---|---|
-| TomTom | segment | 71,266.00 | 0.82% |
-| OpenStreetMap | connector | 1,417,834.00 | 0.35% |
-| OpenStreetMap | segment | 823,258.00 | 0.25% |
+| TomTom | segment | 53,123 | 0.61% |
+| OpenStreetMap | connector | 1,812,753 | 0.44% |
+| OpenStreetMap | segment | 1,097,100 | 0.33% |
 
 ##### Length Changes
 
 | Subtype | Diff (km) | Diff (%) |
 |---|---|---|
-| road | 203,876.72 | 0.22% |
-| rail | 3,115.22 | 0.11% |
-| water | 460.68 | 0.08% |
+| road | 258,124.28 | 0.28% |
+| rail | 3,893.76 | 0.14% |
+| water | 329.78 | 0.06% |
 
 
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Pull Request

Fixes https://github.com/OvertureMaps/data/issues/515.
This pull request adjusts the April OSM cut-off date and change stats for the transportation theme.