### PR TITLE
[DOCS] Update release calendar, links

### DIFF
--- a/docs/release-calendar.mdx
+++ b/docs/release-calendar.mdx
@@ -12,15 +12,20 @@ The latest Overture data release is:
 
 <QueryBuilder query="__OVERTURE_RELEASE/" language="text"></QueryBuilder>
 
-## Release schedule
+## Proposed release schedule
 
-Our planned release schedule is below. Release dates and schema versions are subject to change.
+Our proposed release schedule is below. Release dates and schema versions are subject to change.
 
-| Date             | Data version                                                                   | Schema version                                                           |
-| ---------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
-| 15 April 2026    | [`2026-04-15.0`](https://docs.overturemaps.org/blog/2026/04/15/release-notes/) | [`v1.16.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.16.0) |
-| 20 May 2026      | `2026-05-20.0`                                                                 | TBD                                                                     |
-| 17 June 2026\*   | `2026-06-17.0`                                                                 | TBD                                                                      |
+| Date                | Data version        | Schema version        |
+| ------------------- | ------------------- | --------------------- |
+| 20 May 2026         | `2026-05-20.0`      | TBD                   |
+| 17 June 2026\*      | `2026-06-17.0`      | TBD                   |
+| 22 July 2026        | `2026-07-22.0`      | TBD                   |
+| 19 August 2026      | `2026-08-18.0`      | TBD                   |
+| 23 September 2026\* | `2026-09-23.0`      | TBD                   |
+| 21 October 2026     | `2026-10-21.0`      | TBD                   |
+| 18 November 2026    | `2026-11-18.0`      | TBD                   |
+| 16 December 2026\*  | `2026-12-16.0`      | TBD                   |
 
 \*reserved for quarterly major breaking change release
 
@@ -58,7 +63,8 @@ Overture has been releasing data monthly since October 2023. Past releases are l
 
 | Date              | Data version                                                                   | Schema version                                                           |
 | ----------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
-| 18 March 2026     | [`2026-03-18.0`](https://docs.overturemaps.org/blog/2026/03/18/release-notes/) | [`v1.16.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.16.0) |  
+| 15 April 2026     | [`2026-04-15.0`](https://docs.overturemaps.org/blog/2026/04/15/release-notes/) | [`v1.16.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.16.0) |
+| 18 March 2026     | [`2026-03-18.0`](https://docs.overturemaps.org/blog/2026/03/18/release-notes/) | [`v1.16.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.16.0) |
 | 18 February 2026  | [`2026-02-18.0`](https://docs.overturemaps.org/blog/2026/02/18/release-notes/) | [`v1.16.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.16.0) |
 | 21 January 2026   | [`2026-01-21.0`](https://docs.overturemaps.org/blog/2026/01/21/release-notes/) | [`v1.15.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.15.0) |
 | 17 December 2025  | [`2025-12-17.0`](https://docs.overturemaps.org/blog/2025/12/17/release-notes/) | [`v1.15.0`](https://github.com/OvertureMaps/schema/releases/tag/v1.15.0) |


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Pull Request

Fixes https://github.com/OvertureMaps/docs/issues/374

This pull request adds proposed release dates through December 2026 and adjusts the release history to include April.
