### PR TITLE
[ENHANCEMENT] Update ESA Worldcover attribution

### DIFF
--- a/docs/_generated_attribution.mdx
+++ b/docs/_generated_attribution.mdx
@@ -281,7 +281,7 @@
 **License for theme:** [ODbL](https://opendatacommons.org/licenses/odbl/)
 - © OpenStreetMap contributors. Available under the [Open Database License](https://www.openstreetmap.org/copyright).
 - Data from the [Daylight Map Distribution](https://daylightmap.org/)
-- [ESA WorldCover](https://esa-worldcover.org/en/data-access). Available under [CC BY 4.0 DEED](https://creativecommons.org/licenses/by/4.0/).
+- [ESA WorldCover](https://esa-worldcover.org/en/data-access). © ESA WorldCover project 2020 / Contains modified Copernicus Sentinel data (2020) processed by ESA WorldCover consortium. Available under [CC BY 4.0 DEED](https://creativecommons.org/licenses/by/4.0/).
 - Data products from [ETOPO1](https://www.ncei.noaa.gov/products/etopo-global-relief-model). Available under [Open Data Commons Public Domain Dedication and License](https://www.nature.com/articles/s41597-022-01132-9).
 - Data from [GLOBathy](https://www.nature.com/articles/s41597-022-01132-9). Available under [CC0 1.0 (assumed)](https://www.nature.com/articles/s41597-022-01132-9).
 </details>


### PR DESCRIPTION
Fixes https://github.com/OvertureMaps/docs/issues/399

## Description

Updates the ESA Worldcover attribution text on the Licensing and Attribution page.

> © ESA WorldCover project [year] / Contains modified Copernicus Sentinel data ([year]) processed by ESA WorldCover consortium. Available under [CC BY 4.0 DEED](https://creativecommons.org/licenses/by/4.0/).