### PR TITLE
[CHORE](redirects) Auto redirect from prior releases address

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -98,6 +98,17 @@ const config = {
     ? []
     : [
         [
+          '@docusaurus/plugin-client-redirects',
+          {
+            redirects: [
+              {
+                from: '/releases',
+                to: '/release-calendar/',
+              },
+            ],
+          },
+        ],
+        [
           '@docusaurus/plugin-content-pages',
           {
             id: 'community',

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@docusaurus/core": "^3.10.1",
         "@docusaurus/faster": "^3.10.1",
+        "@docusaurus/plugin-client-redirects": "^3.10.1",
         "@docusaurus/preset-classic": "^3.10.1",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.1.1",
@@ -3899,6 +3900,30 @@
       "peerDependencies": {
         "react": "*",
         "react-dom": "*"
+      }
+    },
+    "node_modules/@docusaurus/plugin-client-redirects": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.10.1.tgz",
+      "integrity": "sha512-LHgd+YDvkhfOHMAE6XtUng3DQNzVM765RqVRrMJgHtzAvfopQhY6ieprqjxDVBdv21cLma6I0jHr+YCZH8fL9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-common": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
+        "eta": "^2.2.0",
+        "fs-extra": "^11.1.1",
+        "lodash": "^4.17.21",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@docusaurus/core": "^3.10.1",
     "@docusaurus/faster": "^3.10.1",
+    "@docusaurus/plugin-client-redirects": "^3.10.1",
     "@docusaurus/preset-classic": "^3.10.1",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.1.1",


### PR DESCRIPTION
Per the issue, this will give us a redirect from `/releases` to resurrect any dead URLs that were not updated to point to `/release-calendar`.

> [!NOTE]
> Due to the janky CloudFront setup for the staging deploy, it won't work (well) - but this works as expected locally, and will work in production (GH Pages based)