### PR TITLE
[TEST] Testing dual-docs build (auto/manual)

### DIFF
--- a/License
+++ b/License
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Overture Maps
+Copyright (c) 2026 Overture Maps
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Pull Request

Exemplar pull request to trigger dual-builds of the docs site: manual-kept schema docs and also ones generated directly from the schema itself.