### PR TITLE
[TEST] Fix false-positive MDX import check in llms-output tests

### DIFF
--- a/src/__tests__/llms-output.test.js
+++ b/src/__tests__/llms-output.test.js
@@ -15,6 +15,12 @@ const LLMS_TXT = join(BUILD_DIR, 'llms.txt');
 const LLMS_FULL_TXT = join(BUILD_DIR, 'llms-full.txt');
 const LLMS_SCHEMA_TXT = join(BUILD_DIR, 'llms-schema.txt');
 
+// Docs legitimately include JS import statements inside fenced code samples
+// (e.g. the maplibre-gl setup snippet in build-a-map.mdx). Strip fenced code
+// blocks before checking for leftover MDX-level imports so those samples
+// don't trip the "no stray imports" assertion below.
+const stripFencedCodeBlocks = (content) => content.replace(/^```[\s\S]*?^```$/gm, '');
+
 describe('llms.txt build output', () => {
   it.skipIf(!existsSync(LLMS_TXT))('llms.txt follows llmstxt.org format', () => {
     const content = readFileSync(LLMS_TXT, 'utf-8');
@@ -27,7 +33,7 @@ describe('llms.txt build output', () => {
   });
 
   it.skipIf(!existsSync(LLMS_TXT))('llms.txt does not contain MDX import statements', () => {
-    const content = readFileSync(LLMS_TXT, 'utf-8');
+    const content = stripFencedCodeBlocks(readFileSync(LLMS_TXT, 'utf-8'));
     // excludeImports: true should strip these
     expect(content).not.toMatch(/^import\s+.+from\s+['"]/m);
   });
@@ -52,7 +58,7 @@ describe('llms-full.txt build output', () => {
   it.skipIf(!existsSync(LLMS_FULL_TXT))(
     'llms-full.txt does not contain MDX import statements',
     () => {
-      const content = readFileSync(LLMS_FULL_TXT, 'utf-8');
+      const content = stripFencedCodeBlocks(readFileSync(LLMS_FULL_TXT, 'utf-8'));
       expect(content).not.toMatch(/^import\s+.+from\s+['"]/m);
     },
   );


### PR DESCRIPTION
Fixes #472

## Problem

CI on main was failing `llms-full.txt does not contain MDX import statements` in `src/__tests__/llms-output.test.js`. The assertion checks the whole built file for any line matching `/^import\s+.+from\s+['"]/m`.

## Root cause

`docs/examples/build-a-map.mdx` has a legitimate fenced `javascript` code sample showing real maplibre-gl/pmtiles setup:

```javascript
import maplibregl from 'maplibre-gl';
import { Protocol } from 'pmtiles';
```

`docusaurus-plugin-llms`'s `excludeImports` option correctly leaves this alone — it's example code for the reader, not an MDX-level import. But the test's regex can't tell the difference and flags it as a leftover MDX import.

## Fix

Strip fenced code blocks (` ```...``` `) before running the "no stray imports" check in both the `llms.txt` and `llms-full.txt` tests, so real MDX imports are still caught while example code is ignored.

## Testing

- `npx vitest run src/__tests__/llms-output.test.js` — 7/7 passed
- `npm test` — 118/118 passed
