### PR TITLE
[BUG] Correct broken guide links in theme definitions table

### DIFF
--- a/static/theme-definitions-table.html
+++ b/static/theme-definitions-table.html
@@ -131,7 +131,7 @@
       const THEME_DATA = {
   "themes": {
     "Addresses": {
-      "guide": "./addresses",
+      "guide": "/guides/addresses/",
       "brief_description": "Unique geographic points representing a physical address location.",
       "licenses": [
         {
@@ -237,7 +237,7 @@
       ]
     },
     "Base": {
-      "guide": "./base",
+      "guide": "/guides/base/",
       "brief_description": "Foundational layers such as land, water, infrastructure, and bathymetry.",
       "licenses": [
         {
@@ -333,7 +333,7 @@
       ]
     },
     "Buildings": {
-      "guide": "./buildings",
+      "guide": "/guides/buildings/",
       "brief_description": "Permanent human-made structures with a roof.",
       "licenses": [
         {
@@ -473,7 +473,7 @@
       ]
     },
     "Divisions": {
-      "guide": "./divisions",
+      "guide": "/guides/divisions/",
       "brief_description": "Recognized areas for governance, culture, or organization.",
       "licenses": [
         {
@@ -565,7 +565,7 @@
       ]
     },
     "Places": {
-      "guide": "./places",
+      "guide": "/guides/places/",
       "brief_description": "Concrete, physically identifiable, stationary destinations.",
       "licenses": [
         {
@@ -693,7 +693,7 @@
       ]
     },
     "Transportation": {
-      "guide": "./transportation",
+      "guide": "/guides/transportation/",
       "brief_description": "Traversable segments (roads, railways, ferries) and connectors (intersections), representing how people and objects travel.",
       "licenses": [
         {

--- a/static/theme-definitions-table.html
+++ b/static/theme-definitions-table.html
@@ -131,7 +131,7 @@
       const THEME_DATA = {
   "themes": {
     "Addresses": {
-      "guide": "/guides/addresses/",
+      "guide": "./guides/addresses/",
       "brief_description": "Unique geographic points representing a physical address location.",
       "licenses": [
         {
@@ -237,7 +237,7 @@
       ]
     },
     "Base": {
-      "guide": "/guides/base/",
+      "guide": "./guides/base/",
       "brief_description": "Foundational layers such as land, water, infrastructure, and bathymetry.",
       "licenses": [
         {
@@ -333,7 +333,7 @@
       ]
     },
     "Buildings": {
-      "guide": "/guides/buildings/",
+      "guide": "./guides/buildings/",
       "brief_description": "Permanent human-made structures with a roof.",
       "licenses": [
         {
@@ -473,7 +473,7 @@
       ]
     },
     "Divisions": {
-      "guide": "/guides/divisions/",
+      "guide": "./guides/divisions/",
       "brief_description": "Recognized areas for governance, culture, or organization.",
       "licenses": [
         {
@@ -565,7 +565,7 @@
       ]
     },
     "Places": {
-      "guide": "/guides/places/",
+      "guide": "./guides/places/",
       "brief_description": "Concrete, physically identifiable, stationary destinations.",
       "licenses": [
         {
@@ -693,7 +693,7 @@
       ]
     },
     "Transportation": {
-      "guide": "/guides/transportation/",
+      "guide": "./guides/transportation/",
       "brief_description": "Traversable segments (roads, railways, ferries) and connectors (intersections), representing how people and objects travel.",
       "licenses": [
         {


### PR DESCRIPTION
Closes https://github.com/OvertureMaps/docs/issues/482

Theme guide links used relative paths like ./addresses, resolving to dead links (e.g. /addresses) instead of the actual guide URLs under /guides/. Fixed all six theme guide links (Addresses, Base, Buildings, Divisions, Places, Transportation).
